### PR TITLE
Fix memory leak in CmSqrtMult when `m_out` is already allocated

### DIFF
--- a/f90/INV/INVcore.f90
+++ b/f90/INV/INVcore.f90
@@ -251,7 +251,7 @@ Contains
    ! to minimize changes.
 
    type(modelParam_t), intent(in)              :: m_in
-   type(modelParam_t), intent(out)             :: m_out
+   type(modelParam_t), intent(inout)             :: m_out
 
 	! apply the operator Cm^(1/2) here
 	! m_out = m_in


### PR DESCRIPTION
This very simple change fixes a memory leak that was occurring when `CmSqrtMult` was called when the `m_out` argument was already allocated. Below is the Valgrind report for this entry that was generated when running a GFortran compiled model:

600,576 bytes in 1 blocks are definitely lost in loss record 75 of 80
   at 0x442FA1B: malloc (vg_replace_malloc.c:446)
   by 0x2005EA07: __sg_scalar_MOD_create_rscalar (sg_scalar.f90:374)
   by 0x20091226: __modelspace_MOD_create_modelparam (ModelSpace.f90:203)
   by 0x2008EDF9: __modelspace_MOD_copy_modelparam (ModelSpace.f90:566)
   by 0x20180F17: __invcore_MOD_cmsqrtmult (INVcore.f90:258)
   by 0x2018801E: __nlcg_MOD_nlcgsolver (NLCG.f90:303)
   by 0x201A390F: MAIN__ (Mod3DMT.f90:255)
   by 0x201A4C5D: main (Mod3DMT.f90:8)

There is also one similar finding that starts from the inside the NLCG solver loop:

    by 0x20189020: __nlcg_MOD_nlcgsolver (NLCG.f90:394)

Because `CmSqrtMult` is called from within the NLCG solver loop, memory is lost every iteration of the NLCG solver loop.

According to the standard, an argument of a procedure with `intent(out)` becomes 'undefined except for components of an object of derived type for which default initialization has been specified' when entering into the procedure.  Thus, the components of `m_out` are set to the default value when `cmSqrtMult` is called, if `m_out` is already allocated.

This sets `m_out % allocated` to `.false.`, which causes `copy_modelParam` to not deallocated `m_out`, thus the first allocation contained in `m_out` is not deallocated and becomes lost.

This will save some marginal savings, for the Cascade case (48x46x34) this will save roughly 1/2 of a megabyte; for Anna's CONUS case (304x674x4), this equates to a 75 MB savings per call to `CmSqrtMult`.

It is worth noting that this memory leak doesn't occur with the classic Intel compiler.  I am guessing this is because iFort tends to not be so strict when you get a little deeper into the standard; however, it does occur with the new Intel ifx compiler, ifx/OneAPI and GFortran.