### PR TITLE
Fix compilation error where output_level was undefined

### DIFF
--- a/f90/MPI/Declaration_MPI.f90
+++ b/f90/MPI/Declaration_MPI.f90
@@ -1,5 +1,6 @@
 
 Module Declaration_MPI
+     use file_units
      use math_constants
 #ifdef MPI
      use mpi


### PR DESCRIPTION
This quick fix adds in `use file_units` to the top of `Declaration_MPI` to ensure the global variable output_level in the `file_units` module is found.

This error was occurring when compiling with MPI with the following error:

```
MPI/Declaration_MPI.f90:296:21:

  296 |      if (output_level .gt. 3) then
      |                     1
Error: Symbol 'output_level' at (1) has no IMPLICIT type
```