### PR TITLE
(DO NOT MERGE) Add a Dockerfile that is able to compile and run ModEM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:latest
+
+ARG ncpus=1
+
+WORKDIR /root/
+
+RUN apt-get update
+RUN echo "Building with ${ncpus} processes"
+
+RUN apt-get -y install gcc-14
+RUN apt-get -y install g++-14
+RUN apt-get -y install gfortran-14
+RUN apt-get -y install libblas-dev
+RUN apt-get -y install liblapack-dev
+RUN apt-get -y install make
+RUN apt-get -y install wget
+RUN apt-get -y install python3
+RUN apt-get -y install vim
+RUN apt-get -y install git
+
+RUN wget https://www.mpich.org/static/downloads/4.3.1/mpich-4.3.1.tar.gz
+RUN tar -xzvf mpich-4.3.1.tar.gz
+
+# Install MPICH Manually as the apt-get install uses pmix and 
+# that will mess with things
+WORKDIR mpich-4.3.1
+RUN CC=gcc-14 CXX=g++-14 FC=gfortran-14 ./configure --with-pm=hydra
+RUN make -j${ncpus} && make -j${ncpus} install
+ENV LD_LIBRARY_PATH=/usr/local/lib/
+WORKDIR /root/
+RUN rm -rf mpich-4.3.1.tar.gz mpich-4.3.1
+

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Modular Electromagnetic Inversion Software (ModEM)
 * [Basic ModEM Usage](#basic-modem-usage)
     * [Forward Modeling](#forward-modeling)
     * [Inversion Modeling](#inversion-modeling)
+* [Building and Running in Docker](#building-and-running-in-docker)
 * [More Information And Tools](#more-information-and-tools)
     * [Related Repositories](#related-repositories)
     * [ModEM-ON and ModEM-OO](#modem-on-and-modem-oo)
@@ -250,6 +251,67 @@ compiled with `-DFG`):
 ``` bash
 $ mpiexec -n 9 ./Mod3DMT -I NLCG pr.ws de.dat block2.inv
 ```
+
+# Building and Running In Docker
+
+A [Dockerfile][Dockerfile] has been provided that will create an Ubuntu docker
+container where you can compile and run ModEM. To run the ModEM docker
+container, first ensure you have [docker installed][Docker-Getting-Started] and
+running (Either have the docker [deamon running][Damon-running], or Docker
+[Desktop running][Docker-desktop].
+
+## Building
+
+After you install Docker, you will need to build the docker container. Inside
+the `ModEM` directory (where the `Dockerfile` resides), run the following:
+
+```bash
+$ docker build . -t modem:latest --build-args ncpus=2
+```
+
+You can specify different numbers of arguments in the `ncpus` build argument if
+you wish. It will speed up the time when Docker compiles MPICH.
+
+After running the above command Docker will create an image named
+`modem:latest` that you can then use to run; it will have all necessary
+libraries and compilers to compile and run ModEM.
+
+## Running and building ModEM in Docker
+
+To run the container, we need to run `docker run`; however, we will also need
+to pass in a `--mount` option to mount our source code into our docker
+container:
+
+```bash
+$ docker run --mount=type=bind,source=/abosolute/path/to/ModEM,target=/root/ModEM -it modem
+```
+
+This will run the container and the `-it` argument will tell Docker to start an
+interactive tty session and will drop you inside the running container. You
+will find that the ModEM source code that you specified in the `source` mount
+argument will be present. Any changes you make in this folder, in either the
+container or the host machine will be present on the other machine.
+
+Once you're inside the container, `cd` into `ModEM/f90`. There, you can run the
+`./CONFIG/Configure.3D_MT.Docker.GFortran` and `make` as described in other
+sections above.
+
+## Specifying additional mounts
+
+It might be helpful to specify additional mount points, for instance it might
+be helpful to mount a work directory, such as the ModEM-Examples repository:
+
+`
+```bash
+$ docker run --mount=type=bind,source=/abosolute/path/to/ModEM,target=/root/ModEM \
+             --mount=type=bind,soucr=/home/users/uname/ModEM-Examples,target=/root/ModEM-Examples \
+             -it modem
+```
+
+[Docker-desktop]: https://www.docker.com/blog/getting-started-with-docker-desktop/
+[Damon-running]: https://docs.docker.com/engine/daemon/start/
+[Docker-Getting-Started]: https://www.docker.com/get-started/
+[Dockerfile]:./Dockerfile
 
 # More Information and Tools
 

--- a/f90/CONFIG/Configure.3D_MT.Docker.GFortran
+++ b/f90/CONFIG/Configure.3D_MT.Docker.GFortran
@@ -1,0 +1,62 @@
+#!/bin/sh
+if [ $# -le 1 ]; then
+    echo 1>&2 Usage: $0 Makefile [debug|release|MPI] [spherical]
+    exit 127
+fi
+if [ -e $1 ]; then
+    rm $1
+fi
+if [ $2 = "debug" ]; then
+# Debug configuration
+perl fmkmf.pl -f90 gfortran \
+-opt '-g -fbacktrace -fbounds-check -ffree-line-length-none -fallow-argument-mismatch' \
+-mpi '-x f95-cpp-input' \
+-o './objs/3D_MT/GFortDebug' \
+-l '-llapack -lblas' \
+-lp '/usr/lib/aarch64-linux-gnu/' \
+-p .:INV:LAPACK:SENS:UTILS:FIELDS/FiniteDiff3D:3D_MT:3D_MT/DICT:3D_MT/modelParam:3D_MT/FWD:3D_MT/FWD/Mod2d:3D_MT/ioMod \
+Mod3DMT.f90 > $1
+
+elif [ $2 = "release" ]; then
+# Release configuration
+perl fmkmf.pl -f90 gfortran \
+-opt '-O3 -ffree-line-length-none -fallow-argument-mismatch' \
+-mpi '-x f95-cpp-input' \
+-o './objs/3D_MT/GFortRelease' \
+-l '-llapack -lblas' \
+-lp '/usr/lib/aarch64-linux-gnu/' \
+-p .:INV:LAPACK:SENS:UTILS:FIELDS/FiniteDiff3D:3D_MT:3D_MT/DICT:3D_MT/modelParam:3D_MT/FWD:3D_MT/FWD/Mod2d:3D_MT/ioMod \
+Mod3DMT.f90 > $1
+
+else
+# MPI configuration (not tested)
+perl fmkmf.pl -f90 mpifort \
+-opt '-O3 -ffree-line-length-none -fallow-argument-mismatch' \
+-mpi '-x f95-cpp-input -DMPI' \
+-o './objs/3D_MT/GFortReleaseMPI' \
+-l '-llapack -lblas' \
+-lp '/usr/lib/aarch64-linux-gnu/' \
+-p .:INV:MPI:LAPACK:SENS:UTILS:FIELDS/FiniteDiff3D:3D_MT:3D_MT/DICT:3D_MT/modelParam:3D_MT/FWD:3D_MT/FWD/Mod2d:3D_MT/ioMod \
+Mod3DMT.f90 > $1
+fi
+
+# Fix the MODULE directory for temporary object files - done in fmkmf.pl already
+# sed -i 's/-module/-fintrinsic-modules-path/' $1
+
+if [ $# -le 2 ]; then
+    echo 1>&2 Cartesian version of the makefile ready to use.
+    exit
+fi
+
+if [ $3 = "spherical" ]; then
+	sed -i.bak 's/GFort/GFortS/g' $1
+	sed -i .bak 's/GridCalc\./GridCalcS\./g' $1
+	sed -i .bak 's/boundary_ws\./boundary_wsS\./g' $1	
+	sed -i .bak 's/3DMT /3DMT_sph /g' $1
+	sed -i .bak 's/3DMT:/3DMT_sph:/g' $1
+	#sed -i .bak 's/\.\/objs\/3D_MT\/(\w+)/\.\/objs\/3D_MT\/(\w+)s/g' $1	
+	rm $1.bak
+    echo 1>&2 Spherical version of the makefile ready to use.
+else
+    echo 1>&2 Cartesian version of the makefile ready to use.
+fi


### PR DESCRIPTION
This merge introduces a Dockerfile to the ModEM repository in an Ubuntu container. So far, the Dockerfile installs LAPACK, LABLAS, GCC-14, GFortran-14, g++-14 and 'manually' builds MPICH-4.3.1 along with a few other helpful programs to have around.

I needed to configure and compile 'manually' here, rather than use `apt-get` as the `apt-get` binary is configured with the `--with-pm=pmix`. Apparently, newer versions of Ubuntu come with and updated PMIX which can cause issues when running mpiexec, thus, we needed to configure MPICH to use hydra here instead of PMIX.

It should be pretty easy to add additional libraries here if we desire (CUDA, HIP, HDF5 etc.), but this will be a good starting point.

For reference, I've mostly done created this so I can use GDB in a non-slurm environment. Apple silicone often doesn't produce meaningful traceback messages for Fortran and I am tired of fighting with slurm, srun and Cray systems shenanigans.