### PR TITLE
Correct run-time error in write for GFortran-15

### DIFF
--- a/f90/UserCtrl.f90
+++ b/f90/UserCtrl.f90
@@ -297,7 +297,7 @@ Contains
      if (narg > 1) then
         write(6,*) 'Running job -',job,' with command line options:'
         do k = 1,narg-1
-          write(6,'(x1a)',advance='no') trim(temp(k))
+          write(6,'(x,A)',advance='no') trim(temp(k))
         end do
         write(6,*)
         write(6,*)


### PR DESCRIPTION
GFortran-15 apparent no longer approves of this write statement in UserCtrl and throws a run-time error when printing out this error statement when writing:

`Fortran runtime error: Missing comma between descriptors`

I'm not sure if the previous format was standard complaint, but I'm inclined to think it was not, but I am not sure why it worked for so long.

Regardless, the change in the format for this write statement matches the expected output, i.e. the argument separated by a space.