### PR TITLE
Introduce expand_string and a new module for logging (mostly for debugging)

### DIFF
--- a/f90/UTILS/CMakeLists.txt
+++ b/f90/UTILS/CMakeLists.txt
@@ -5,11 +5,10 @@ target_sources(${MODEM_EXE}
     PRIVATE fields_orientation.f90
     PRIVATE file_units.f90
     PRIVATE math_constants.f90
-    #PRIVATE ModEM_machine_timers.c
     PRIVATE ModEM_timers.f90
-    #PRIVATE ModEM_utils.f90
     PRIVATE polpak.f90
     PRIVATE utilities.f90
+    PRIVATE ModEM_logger.f90
 )
 
 if (USE_C_TIMERS)

--- a/f90/UTILS/ModEM_logger.f90
+++ b/f90/UTILS/ModEM_logger.f90
@@ -1,0 +1,152 @@
+module ModEM_logger
+
+    use utilities
+    use Declaration_MPI
+
+implicit none
+
+    character (len=512), private ::  log_fname
+    integer, private :: log_fid = 0
+
+contains
+
+subroutine ModEM_log_init(mainOnly)
+
+      implicit none
+
+      logical, optional, intent(in) :: mainOnly 
+      character(len=*), parameter :: log_str_fmt = '(A,I4.4,A)'
+
+      logical :: mainOnly_lcl
+
+      if (present(mainOnly)) then
+        mainOnly_lcl = mainOnly
+      else
+        mainOnly_lcl = .true.
+      end if
+
+      if ((taskid == 0 .and. mainOnly_lcl) .or. (.not. mainOnly_lcl)) then
+          write(log_fname, log_str_fmt) 'log.', taskid, '.modem.out'
+          open(newunit=log_fid, file=log_fname, status='replace')
+          call ModEM_log("Log Initalized $i - "//trim(log_fname), intArgs=(/taskid/), mainOnly=mainOnly)
+      end if
+
+end Subroutine ModEM_log_init
+
+! The following License applies to ModEM_Log:
+!
+! Copyright (c) 2013-2019,  Los Alamos National Security, LLC (LANS) (Ocean: LA-CC-13-047;
+! Land Ice: LA-CC-13-117) and the University Corporation for Atmospheric Research (UCAR).
+!
+! All rights reserved.
+!
+! LANS is the operator of the Los Alamos National Laboratory under Contract No.
+! DE-AC52-06NA25396 with the U.S. Department of Energy.  UCAR manages the National
+! Center for Atmospheric Research under Cooperative Agreement ATM-0753581 with the
+! National Science Foundation.  The U.S. Government has rights to use, reproduce,
+! and distribute this software.  NO WARRANTY, EXPRESS OR IMPLIED IS OFFERED BY
+! LANS, UCAR OR THE GOVERNMENT AND NONE OF THEM ASSUME ANY LIABILITY FOR THE USE
+! OF THIS SOFTWARE.  If software is modified to produce derivative works, such
+! modified software should be clearly marked, so as not to confuse it with the
+! version available from LANS and UCAR.
+!
+! Additionally, redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions are met:
+!
+! 1) Redistributions of source code must retain the above copyright notice, this
+! list of conditions and the following disclaimer.
+!
+! 2) Redistributions in binary form must reproduce the above copyright notice,
+! this list of conditions and the following disclaimer in the documentation and/or
+! other materials provided with the distribution.
+!
+! 3) None of the names of LANS, UCAR or the names of its contributors, if any, may
+! be used to endorse or promote products derived from this software without
+! specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+! ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+! ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+!***********************************************************************
+!
+!  routine ModEM_log
+!
+!> \brief   Writes a message to the log file
+!> \author  Matt Hoffman - Modified for ModEM by Miles Curry
+!> \date    14 February 2017, 5 Feburary 2026
+!> \details
+!>  This routine writes a message to the log file.  The message is the only
+!>  required argument.  A number of optional arguments control additional
+!>  behavior:
+!>    intArgs, int8Args, realArgs, logicArgs:  arrays of variable values to be inserted into the
+!>                                   message to replace the following characters: $i, $j, $r, $l
+!>                                   See routine expand_string below for details.
+!>    fid: (Optional) Instead of using the log created/opened in ModEM_log_init, write to the unit
+!>         in found in fid
+!>    mainOnly: flag indicating only the master task should write this message,
+!>                regardless of if all tasks have open log files.
+!>    flush_log: flag indicating that the log should be flushed after writing
+!>                
+!
+!-----------------------------------------------------------------------
+subroutine ModEM_log(msg, intArgs, realArgs, logicArgs, fid, mainOnly, flush_log)
+
+   implicit none
+
+   character(len=*), intent(in) :: msg
+   logical, intent(in), optional :: mainOnly
+   integer, dimension(:), intent(in), optional :: intArgs  !< Input: integer variable values to insert into message
+   real(kind=prec), dimension(:), intent(in), optional :: realArgs  !< Input: real variable values to insert into message
+        !< Input: exponential notation variable values to insert into message
+   logical, dimension(:), intent(in), optional :: logicArgs  !< Input: logical variable values to insert into message
+   integer, intent(in), optional :: fid
+   logical, intent(in), optional :: flush_log
+
+   logical :: mainOnly_lcl
+   logical :: flush_lcl
+   integer :: fid_lcl
+
+   character(len=512) :: messageExpanded !< message after expansion of $ variable insertions
+
+   if (present(mainOnly)) then
+       mainOnly_lcl = mainOnly
+   else
+       mainOnly_lcl = .true.
+   end if
+
+   if (present(fid)) then
+        fid_lcl = fid
+   else
+        fid_lcl = log_fid
+   end if
+
+
+   if (present(flush_log)) then
+       flush_lcl = flush_log
+   else
+        flush_lcl = .false.
+   end if
+
+   call expand_string(msg, messageExpanded, intArgs, logicArgs, realArgs)
+
+   if ((mainOnly_lcl .and. taskid == 0) .or. (.not. mainOnly_lcl)) then
+       write(0,*) fid_lcl
+       write(fid_lcl,*) trim(messageExpanded)
+
+       if (flush_lcl) then
+           call flush(fid_lcl)
+       end if
+    end if
+
+end subroutine ModEM_log
+
+end module ModEM_logger
+

--- a/f90/UTILS/ModEM_logger.f90
+++ b/f90/UTILS/ModEM_logger.f90
@@ -189,7 +189,6 @@ subroutine ModEM_log(msg, intArgs, realArgs, logicArgs, fid, mainOnly, flush_log
    call expand_string(msg, messageExpanded, intArgs, logicArgs, realArgs)
 
    if ((mainOnly_lcl .and. taskid == 0) .or. (.not. mainOnly_lcl)) then
-       write(0,*) fid_lcl
        write(fid_lcl,*) trim(messageExpanded)
 
        if (flush_lcl) then

--- a/f90/UTILS/ModEM_logger.f90
+++ b/f90/UTILS/ModEM_logger.f90
@@ -1,3 +1,24 @@
+!
+! ModEM_logger
+! 
+!  This logger, along with `expand_message` in the utilities modular, offer
+!  some very helpful mechanisms for logging messages in Fortran. It offers:
+!
+!  1. Easily allow each MPI task the ability to open and log to its own seperate
+!   logging file.
+!   * Very Helpful in debugging MPI Issues
+!  2. The ability to use printf-like string formatting.
+!   * Reduces the need to use Fortran's ... unique string formatting mechanism
+! 
+!  To use, ensure you call ModEM_log_init() first before doing calling ModEM_log().
+!  For examples, please see the code comments in ModEM_log below.
+!
+! By default, only the main task will log out tasks. Likewise, you might not see
+! messages immediate during execution, so you might want to use flush_log=.true. when
+! calling ModEM_log.
+!
+! Note: The code in the section was adapted from MPAS-Model code: see the
+! license disclosure below.
 module ModEM_logger
 
     use utilities
@@ -94,8 +115,39 @@ end Subroutine ModEM_log_init
 !>    mainOnly: flag indicating only the master task should write this message,
 !>                regardless of if all tasks have open log files.
 !>    flush_log: flag indicating that the log should be flushed after writing
-!>                
-!
+!>
+!>  For more information see the expand_string subroutine in the utilities module
+!>
+!> | examples
+!>    
+!>    ```Fortran
+!>      real :: a, b, c         ! Of course you can also use other real kinds
+!>      integer :: int1, int2,
+!>      logical :: bool_false, bool_true
+!>
+!>      ! Ensure you call ModEM_log_init() first!
+!>      call ModEM_log_init()
+!>      
+!>      ! Printing several real numbers:
+!>      call ModEM_log("Reals: a: $r b: $r c: $r", realArgs=(/a, b, c/)))
+!>
+!>      ! Printing several integer numbers
+!>      call ModEM_log("Integers: ($i, $i)", intArgs=(/int1, int2/)))
+!> 
+!>      ! Printing logicals
+!>      bool_false = .false. 
+!>      bool_true = .true.
+!>      call ModEM_log("Logical: $l $l", logicArgs=(/bool_false, bool_true/))
+!>
+!>      ! Mix and match as you see fit!
+!>      ! Note: You don't need to have the arguments (intArgs, logicArgs etc.) in any particular order!
+!>      call ModEM_log("Bool: $l - Int: $i - Reals: $r $r $r", intArgs=(/int1/), logicArgs=(/bool_true/), &
+!>                          realArgs=(/a, b, c/))
+!>
+!>      ! Appending Strings
+!>      myString = "JOB_NAME"
+!>      call ModEM_log("We are in the: '"//trim(myString)//"' function with args: $i, $i", intArgs=(/int1, int2/))
+!>    ```
 !-----------------------------------------------------------------------
 subroutine ModEM_log(msg, intArgs, realArgs, logicArgs, fid, mainOnly, flush_log)
 
@@ -127,7 +179,6 @@ subroutine ModEM_log(msg, intArgs, realArgs, logicArgs, fid, mainOnly, flush_log
    else
         fid_lcl = log_fid
    end if
-
 
    if (present(flush_log)) then
        flush_lcl = flush_log

--- a/f90/UTILS/utilities.f90
+++ b/f90/UTILS/utilities.f90
@@ -771,4 +771,200 @@ recursive subroutine QSort(a, ia, i0, i1)
 end subroutine QSort
 
 !**********************************************************************
+
+! The following License applies to expand_string :
+!
+! Copyright (c) 2013-2019,  Los Alamos National Security, LLC (LANS) (Ocean: LA-CC-13-047;
+! Land Ice: LA-CC-13-117) and the University Corporation for Atmospheric Research (UCAR).
+!
+! All rights reserved.
+!
+! LANS is the operator of the Los Alamos National Laboratory under Contract No.
+! DE-AC52-06NA25396 with the U.S. Department of Energy.  UCAR manages the National
+! Center for Atmospheric Research under Cooperative Agreement ATM-0753581 with the
+! National Science Foundation.  The U.S. Government has rights to use, reproduce,
+! and distribute this software.  NO WARRANTY, EXPRESS OR IMPLIED IS OFFERED BY
+! LANS, UCAR OR THE GOVERNMENT AND NONE OF THEM ASSUME ANY LIABILITY FOR THE USE
+! OF THIS SOFTWARE.  If software is modified to produce derivative works, such
+! modified software should be clearly marked, so as not to confuse it with the
+! version available from LANS and UCAR.
+!
+! Additionally, redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions are met:
+!
+! 1) Redistributions of source code must retain the above copyright notice, this
+! list of conditions and the following disclaimer.
+!
+! 2) Redistributions in binary form must reproduce the above copyright notice,
+! this list of conditions and the following disclaimer in the documentation and/or
+! other materials provided with the distribution.
+!
+! 3) None of the names of LANS, UCAR or the names of its contributors, if any, may
+! be used to endorse or promote products derived from this software without
+! specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+! ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+! ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+!-----------------------------------------------------------------------
+!  routine expand_string - (Renamed from mpas_log.F log_expand_string to expand_string)
+!
+!> \brief This is a utility routine that inserts formatted variables into a string.
+!> \author Matt Hoffman
+!> \date   02/20/2017
+!> \details This routine inserts formatted variables into a string.
+!>   The variables to be expanded are represented with a '$' symbol followed
+!>   by one of these indicators:
+!>   $i -> integer, formatted to be length of integer
+!>   $l -> logical, fomatted as 'T' or 'F'
+!>   $r -> real,  formatted as 9 digits of precision for SP mode, 17 for DP mode
+!>                Floats are formatted using 'G' format which is smart about
+!>                displaying as a decimal or scientific notation based on the value.
+!>   The variable values to expand are supplied as optional arguments to this
+!>   routine.  The substitution indicators are expanded as they are encountered.
+!>   Thus, extra variable values will be ignored.  If the supplied variable values
+!>   run out before the $ expansion indicators are all replaced, the remaining
+!>   expansions will be filled with a fill value ('**').  The fill value is also
+!>   used if the expansion indicator is of an unknown type, where the valid types
+!>   are $i, $l, $r.
+!>   If the user prefers more specific formatting, they have to do it external
+!>   to this routine in a local string variable.  Similarly, character variables
+!>   can be handled by the string concatenation command (//).
+!>   This routine is based off of mpas_expand_string.
+!-----------------------------------------------------------------------
+subroutine expand_string(inString, outString, intArgs, logicArgs, realArgs)
+
+  implicit none
+
+  !-----------------------------------------------------------------
+  ! input variables
+  !-----------------------------------------------------------------
+  character (len=*), intent(in) :: inString  !< Input: message to be expanded
+
+  integer, dimension(:), intent(in), optional :: intArgs
+     !< Input, Optional: array of integer variable values to be used in expansion
+  logical, dimension(:), intent(in), optional :: logicArgs
+     !< Input, Optional: array of logical variable values to be used in expansion
+  real(kind=prec), dimension(:), intent(in), optional :: realArgs
+     !< Input, Optional: array of real variable values to be used in expansion
+
+  !-----------------------------------------------------------------
+  ! input/output variables
+  !-----------------------------------------------------------------
+
+  !-----------------------------------------------------------------
+  ! output variables
+  !-----------------------------------------------------------------
+  character (len=512), intent(out) :: outString  !< Output: expanded version of input message after expansion
+
+  !-----------------------------------------------------------------
+  ! local variables
+  !-----------------------------------------------------------------
+  integer :: i, curLen
+  integer :: nInts, nLogicals, nReals, nExps  !< the length of the variable arrays passed in
+  integer :: iInt, iLogical, iReal !< Counter for the current index into each variable array
+  character (len=64) :: realFormat  !< Format string to create to use for writing real variables to log file
+  integer :: realPrecision !< precision of a real variable
+
+  character (len=64) :: varPart
+  character (len=64) :: errVarPart ! string to use if variable expansion fails
+  logical :: charExpand
+
+  ! Initialize the current index for each variable array to 1
+  iInt = 1
+  iLogical = 1
+  iReal = 1
+
+  ! For each variable array, get the size.  Size is 0 if not present.
+  if (present(intArgs)) then
+     nInts = size(intArgs)
+  else
+     nInts = 0
+  endif
+
+  if (present(logicArgs)) then
+     nLogicals = size(logicArgs)
+  else
+     nLogicals = 0
+  endif
+
+  if (present(realArgs)) then
+     nReals = size(realArgs)
+  else
+     nReals = 0
+  endif
+
+  ! Initialize strings
+  write(outString,*) ''
+  write(varPart,*) ''
+  errVarPart = '**'  ! string to use if variable expansion fails
+
+  !Initialize char info
+  curLen = 0
+  charExpand = .false.
+
+  ! Loop over character positions in inString
+  do i = 1, len_trim(inString)
+     if (inString(i:i) == '$' .and. (.not. charExpand)) then
+         charExpand = .true.
+     else
+         if (charExpand) then
+            select case (inString(i:i))
+               case ('i')
+                  ! make the format large enough to include a large integer (up to 17 digits for 8-byte int)
+                  ! it will be trimmed below
+                  if (iInt <= nInts) then
+                     write(varPart,'(i17)') intArgs(iInt)
+                     iInt = iInt + 1
+                  else
+                     varPart = errVarPart
+                  endif
+               case ('l')
+                  if (iLogical <= nLogicals) then
+                     if (logicArgs(iLogical)) then
+                        write(varPart ,'(a)') 'T'
+                     else
+                        write(varPart ,'(a)') 'F'
+                     endif
+                     iLogical = iLogical + 1
+                  else
+                     varPart = errVarPart
+                  endif
+               case ('r')
+                  if (iReal <= nReals) then
+                     realPrecision = precision(realArgs(iReal))
+                     ! Note 7 additional characters may be needed beyond the precision
+                     ! e.g.: -1234567.89012345   G13.6   ->   -0.123457E+07
+                     write(realFormat, '(a, i2.2, a, i2.2, a)') '(G', realPrecision+7,'.', realPrecision, ')'
+                     write(varPart, trim(realFormat)) realArgs(iReal)
+                     iReal = iReal + 1
+                  else
+                     varPart = errVarPart
+                  endif
+               case ('$')
+                     varPart = '$'
+               case default
+                  varPart = errVarPart
+            end select
+            outString = outString(1:curLen) // trim(adjustl(varPart))
+
+            curLen = curLen + len_trim(adjustl(varPart))
+            charExpand = .false.
+         else
+            outString(curLen+1:curLen+1) = inString(i:i)
+            curLen = curLen+1
+         end if
+     end if
+  end do
+
+!--------------------------------------------------------------------
+end subroutine expand_string
 end module utilities


### PR DESCRIPTION
This pull requests adds in a new utility subroutine, `expand_string` and a new module, `ModEM_logger`.

Both of the `expand_string` subroutine and the `ModEM_logger` subroutine are taken from NCAR/Los Alamos National Labratory's MPAS-Model: https://github.com/MPAS-Dev/MPAS-Model/blob/master/src/framework/mpas_log.F. MPAS has a BSD licensces and I have included the license in the source code where `expand_string` and modified `MPAS_log_write` reside.

Currently, either `expand_string` or the `ModEM_logger` are not used anywhere in ModEM (outside of `ModEM_logger` using `expand_string`). The `expand_string` is a very helpful little subroutine that allows a 'printf'-like behavior to formatting strings. There should be numerous usages for such a method.

The ModEM_log is also a helpful function in that it: uses `expand_string` and individual tasks can open their own logs for writing. This can help wonderfully when debugging MPI issues.

While eventually we could replace all previous write log statements, for now I'd like to include these subroutines for debugging and convenience. 