### PR TITLE
feat: GPU locking via atomic operation using POSIX shared memory

### DIFF
--- a/f90/3D_MT/FWD_SP2/EMsolve3D.f90
+++ b/f90/3D_MT/FWD_SP2/EMsolve3D.f90
@@ -542,6 +542,13 @@ Contains
     Call deall(tvec)
     deallocate(KSSiter%rerr)
 
+    ! Release GPU lock so other processes can hook on
+#if defined(CUDA) || defined(HIP)
+    if (device_id >= 0) then
+        call cf_releaseDev(device_id)
+    endif
+#endif
+
   end subroutine FWDsolve3D
 
 #if defined(MPI) && defined(FG)
@@ -1194,6 +1201,14 @@ Contains
    &             rank_local
          end if
      end if
+
+    ! Release GPU lock so other processes can hook on
+#if defined(CUDA) || defined(HIP)
+    if (device_id >= 0 .and. size_local > 1) then
+        call cf_releaseDev(device_id)
+    endif
+#endif
+
      call MPI_BARRIER(comm_local,ierr)
      if (rank_local .eq. 0) then ! Leader 
          ! deallocate local temporary arrays

--- a/f90/3D_MT/FWD_SP2/EMsolve3D.f90
+++ b/f90/3D_MT/FWD_SP2/EMsolve3D.f90
@@ -542,11 +542,12 @@ Contains
     Call deall(tvec)
     deallocate(KSSiter%rerr)
 
-    ! Release GPU lock so other processes can hook on
+    ! Release GPU lock and cleanup shared memory on exit
 #if defined(CUDA) || defined(HIP)
     if (device_id >= 0) then
         call cf_releaseDev(device_id)
-    endif
+    end if
+    call cf_cleanupLock()
 #endif
 
   end subroutine FWDsolve3D
@@ -1206,10 +1207,16 @@ Contains
 #if defined(CUDA) || defined(HIP)
     if (device_id >= 0 .and. size_local > 1) then
         call cf_releaseDev(device_id)
-    endif
+    end if
 #endif
 
      call MPI_BARRIER(comm_local,ierr)
+    ! Cleanup shared-memory lock name (only rank 0)
+#if defined(CUDA) || defined(HIP)
+    if (rank_local .eq. 0) then
+        call cf_cleanupLock()
+    end if
+#endif
      if (rank_local .eq. 0) then ! Leader 
          ! deallocate local temporary arrays
          deallocate(b)

--- a/f90/3D_MT/FWD_SP2/EMsolve3D.f90
+++ b/f90/3D_MT/FWD_SP2/EMsolve3D.f90
@@ -542,12 +542,13 @@ Contains
     Call deall(tvec)
     deallocate(KSSiter%rerr)
 
-    ! Release GPU lock and cleanup shared memory on exit
+    ! Release GPU lock so other processes can hook on
+    ! NOTE: do NOT call cf_cleanupLock() here — the shared-memory lock
+    ! must persist across transmitter iterations
 #if defined(CUDA) || defined(HIP)
     if (device_id >= 0) then
         call cf_releaseDev(device_id)
     end if
-    call cf_cleanupLock()
 #endif
 
   end subroutine FWDsolve3D
@@ -1204,6 +1205,7 @@ Contains
      end if
 
     ! Release GPU lock so other processes can hook on
+    ! NOTE: do NOT call cf_cleanupLock() here — similar to FWDsolve3D.
 #if defined(CUDA) || defined(HIP)
     if (device_id >= 0 .and. size_local > 1) then
         call cf_releaseDev(device_id)
@@ -1211,12 +1213,6 @@ Contains
 #endif
 
      call MPI_BARRIER(comm_local,ierr)
-    ! Cleanup shared-memory lock name (only rank 0)
-#if defined(CUDA) || defined(HIP)
-    if (rank_local .eq. 0) then
-        call cf_cleanupLock()
-    end if
-#endif
      if (rank_local .eq. 0) then ! Leader 
          ! deallocate local temporary arrays
          deallocate(b)

--- a/f90/3D_MT/FWD_SP2/cudaFortMap.f90
+++ b/f90/3D_MT/FWD_SP2/cudaFortMap.f90
@@ -1698,6 +1698,21 @@ module cudaFortMap
    !   ! get the number of GPU devices  
    ! end function kernelc_getDevNum
 
+   ! cf_releaseDev - release the GPU gate so other processes can hook on
+   subroutine cf_releaseDev(device_idx) &
+    &              bind(C, name="cf_releaseDev")
+     use iso_c_binding
+     implicit none
+     integer(c_int), value :: device_idx
+   end subroutine cf_releaseDev
+
+   ! cf_cleanupLock - cleanup shared memory lock on program exit
+   subroutine cf_cleanupLock() &
+    &              bind(C, name="cf_cleanupLock")
+     use iso_c_binding
+     implicit none
+   end subroutine cf_cleanupLock
+
    end interface  
 
 end module

--- a/f90/3D_MT/FWD_SP2/gpu_lock.h
+++ b/f90/3D_MT/FWD_SP2/gpu_lock.h
@@ -1,0 +1,104 @@
+/*
+ * gpu_lock.h — Platform-independent, cross-process GPU locking via POSIX shared memory.
+ *
+ * Multiple MPI ranks can safely target the same GPU:
+ *   cf_hookDev()    — acquires GPU via CAS 0->1 on an atomic flag array (platform-specific)
+ *   cf_releaseDev() — releases the lock so other processes can attach
+ *   cf_cleanupLock()— unmaps and unlinks shared memory on exit
+ */
+
+#ifndef MODEM_GPU_LOCK_H
+#define MODEM_GPU_LOCK_H
+
+#include <atomic>
+#include <fcntl.h>
+#include <new>
+#include <sys/mman.h>
+#include <unistd.h>
+
+/* ------------------------------------------------------------------ */
+/* Device state flags                                                  */
+/* ------------------------------------------------------------------ */
+
+#define DEVICE_FREE  0
+#define DEVICE_IN_USE 1
+
+/* ------------------------------------------------------------------ */
+/* Lock structure & global state                                       */
+/* ------------------------------------------------------------------ */
+
+static constexpr int LOCK_MAX_DEVICES = 64;
+
+/*
+ * Raw byte flag at offset 0 — no C++ object lifetime requirements.
+ * Used *only* to coordinate who runs placement-new on the atomics.
+ */
+struct alignas(64) GpuLock {
+    unsigned char constructed;             /* 0 = raw storage, !=0 = atomics live */
+    std::atomic<int> initialized;          /* cross-process init guard (0->1 CAS) */
+    std::atomic<int> occupied[LOCK_MAX_DEVICES];
+};
+
+static GpuLock* g_lock       = nullptr;
+static bool     g_lock_inited = false;
+
+/* ------------------------------------------------------------------ */
+/* Internal: create / map shared-memory segment and construct atomics  */
+/* ------------------------------------------------------------------ */
+
+static inline int init_gpu_lock()
+{
+    const char* name = "/ModEM_gpu_lock";
+
+    /* Try to open existing shared memory segment first */
+    int fd = shm_open(name, O_RDWR, 0600);
+    if (fd < 0) {
+        /* Doesn't exist -- create it */
+        fd = shm_open(name, O_CREAT | O_RDWR, 0600);
+        if (fd < 0) return 1;
+        if (ftruncate(fd, sizeof(GpuLock)) < 0) { close(fd); return 1; }
+    }
+
+    g_lock = static_cast<GpuLock*>(mmap(nullptr, sizeof(GpuLock),
+                                         PROT_READ | PROT_WRITE,
+                                         MAP_SHARED, fd, 0));
+    close(fd);
+    if (g_lock == MAP_FAILED) { g_lock = nullptr; return 1; }
+
+    /* Begin object lifetimes once across all processes */
+    if (__atomic_test_and_set(&g_lock->constructed, __ATOMIC_ACQ_REL)) {
+        /* we are not the first -- just wait */
+    } else {
+        /* we are the first -- construct the atomics in shared memory */
+        new (&g_lock->initialized) std::atomic<int>(0);
+        for (int i = 0; i < LOCK_MAX_DEVICES; i++)
+            new (&g_lock->occupied[i]) std::atomic<int>(DEVICE_FREE);
+    }
+
+    g_lock_inited = true;
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* Public C-bindings (called from Fortran)                              */
+/* ------------------------------------------------------------------ */
+
+extern "C" void cf_releaseDev(int dev_idx)
+{
+    if (g_lock_inited && g_lock != nullptr &&
+        dev_idx >= 0 && dev_idx < LOCK_MAX_DEVICES)
+    {
+        g_lock->occupied[dev_idx].store(DEVICE_FREE, std::memory_order_release);
+    }
+}
+
+extern "C" void cf_cleanupLock()
+{
+    if (g_lock != nullptr && g_lock != MAP_FAILED)
+        munmap(g_lock, sizeof(GpuLock));
+    shm_unlink("/ModEM_gpu_lock");
+    g_lock = nullptr;
+    g_lock_inited = false;
+}
+
+#endif /* MODEM_GPU_LOCK_H */

--- a/f90/3D_MT/FWD_SP2/gpu_lock.h
+++ b/f90/3D_MT/FWD_SP2/gpu_lock.h
@@ -1,11 +1,6 @@
-/*
- * gpu_lock.h — Platform-independent, cross-process GPU locking via POSIX shared memory.
- *
- * Multiple MPI ranks can safely target the same GPU:
- *   cf_hookDev()    — acquires GPU via CAS 0->1 on an atomic flag array (platform-specific)
- *   cf_releaseDev() — releases the lock so other processes can attach
- *   cf_cleanupLock()— unmaps and unlinks shared memory on exit
- */
+// gpu_lock.h — Platform-independent, cross-process GPU locking via POSIX 
+// shared memory.
+// Multiple MPI ranks (should...) safely target the same GPU:
 
 #ifndef MODEM_GPU_LOCK_H
 #define MODEM_GPU_LOCK_H
@@ -16,44 +11,35 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
-/* ------------------------------------------------------------------ */
-/* Device state flags                                                  */
-/* ------------------------------------------------------------------ */
+// Define device state flags                                                 
 
 #define DEVICE_FREE  0
 #define DEVICE_IN_USE 1
 
-/* ------------------------------------------------------------------ */
-/* Lock structure & global state                                       */
-/* ------------------------------------------------------------------ */
-
+// Lock structure & global state 
+// we probably don't have more than 64 devices on a single node
 static constexpr int LOCK_MAX_DEVICES = 64;
 
-/*
- * Raw byte flag at offset 0 — no C++ object lifetime requirements.
- * Used *only* to coordinate who runs placement-new on the atomics.
- */
+// cnstr: compiler-built-in atomic on raw int — safe before object lifetime begins.
+// All other members are std::atomic<int>, constructed by placement-new once,
+// then used via normal C++ atomic operations.
 struct alignas(64) GpuLock {
-    unsigned char constructed;             /* 0 = raw storage, !=0 = atomics live */
-    std::atomic<int> initialized;          /* cross-process init guard (0->1 CAS) */
+    int cnstr;      // 0 = not constructed, 1 = atomics live
     std::atomic<int> occupied[LOCK_MAX_DEVICES];
 };
 
 static GpuLock* g_lock       = nullptr;
 static bool     g_lock_inited = false;
 
-/* ------------------------------------------------------------------ */
-/* Internal: create / map shared-memory segment and construct atomics  */
-/* ------------------------------------------------------------------ */
-
+// Internal: create / map shared-memory segment and construct atomics 
 static inline int init_gpu_lock()
 {
     const char* name = "/ModEM_gpu_lock";
 
-    /* Try to open existing shared memory segment first */
+    // Try to open existing shared memory segment first 
     int fd = shm_open(name, O_RDWR, 0600);
     if (fd < 0) {
-        /* Doesn't exist -- create it */
+        // Doesn't exist -- create it 
         fd = shm_open(name, O_CREAT | O_RDWR, 0600);
         if (fd < 0) return 1;
         if (ftruncate(fd, sizeof(GpuLock)) < 0) { close(fd); return 1; }
@@ -65,23 +51,30 @@ static inline int init_gpu_lock()
     close(fd);
     if (g_lock == MAP_FAILED) { g_lock = nullptr; return 1; }
 
-    /* Begin object lifetimes once across all processes */
-    if (__atomic_test_and_set(&g_lock->constructed, __ATOMIC_ACQ_REL)) {
-        /* we are not the first -- just wait */
+    // Coordinate exactly-once construction of std::atomic members.   
+    // cnstr uses __atomic_* built-ins: safe on raw storage       
+    // the winner does placement-new on every std::atomic<int>     
+    // the other (losers) spin-wait with ACQUIRE on "cnstr" until it's 1, 
+    // then proceed to use the atomics.
+
+    if (__atomic_exchange_n(&g_lock->cnstr, 1, __ATOMIC_ACQ_REL) != 0) {
+        // Another process won the race — spin-wait until construction finishes.
+        while (!__atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE))
+            ;
     } else {
-        /* we are the first -- construct the atomics in shared memory */
-        new (&g_lock->initialized) std::atomic<int>(0);
+        // We are the winner — construct all std::atomic members.
         for (int i = 0; i < LOCK_MAX_DEVICES; i++)
             new (&g_lock->occupied[i]) std::atomic<int>(DEVICE_FREE);
+
+        // cnstr is already 1 from the exchange above (ACQ_REL ensures
+        // the constructed atomics are visible to other processes).
     }
 
     g_lock_inited = true;
     return 0;
 }
 
-/* ------------------------------------------------------------------ */
-/* Public C-bindings (called from Fortran)                              */
-/* ------------------------------------------------------------------ */
+// Public C-bindings (called from Fortran)                            
 
 extern "C" void cf_releaseDev(int dev_idx)
 {
@@ -101,4 +94,4 @@ extern "C" void cf_cleanupLock()
     g_lock_inited = false;
 }
 
-#endif /* MODEM_GPU_LOCK_H */
+#endif // MODEM_GPU_LOCK_H

--- a/f90/3D_MT/FWD_SP2/hipFortMap.f90
+++ b/f90/3D_MT/FWD_SP2/hipFortMap.f90
@@ -685,7 +685,7 @@ module hipFortMap
 
    ! hipblasZaxpy
    integer(c_int) function cublasZaxpy(handle,n,alpha,x,incx,y,incy) &
-    &             bind(C,name="hipblasZaxpy_v2")
+    &             bind(C,name="hipblasZaxpy")
      ! compute y = y + a*x with complex double precision
      ! note that x and y should be located in GPU memory
      use iso_c_binding
@@ -715,7 +715,7 @@ module hipFortMap
 
    ! hipblasZcopy
    integer(c_int) function cublasZcopy(handle,n,x,incx,y,incy) &
-    &             bind(C,name="hipblasZcopy_v2")
+    &             bind(C,name="hipblasZcopy")
      ! compute y = x with complex double precision
      use iso_c_binding
      implicit none
@@ -729,7 +729,7 @@ module hipFortMap
 
    ! hipblasDdot
    integer(c_int) function cublasDdot(handle,n,x,incx,y,incy,result) &
-    &            bind(C,name="hipblasDdot_v2")
+    &            bind(C,name="hipblasDdot")
      ! compute result = x dot y with double precision
      use iso_c_binding
      implicit none
@@ -744,7 +744,7 @@ module hipFortMap
 
    ! hipblasZdot
    integer(c_int) function cublasZdot(handle,n,x,incx,y,incy,result) &
-    &            bind(C,name="hipblasZdotc_v2")
+    &            bind(C,name="hipblasZdotc")
      ! compute result = x dot y with complex double precision
      use iso_c_binding
      implicit none
@@ -772,7 +772,7 @@ module hipFortMap
 
    ! hipblasZnrm2 there is no such thing like znrm2!
    integer(c_int) function cublasZnrm2(handle,n,x,incx,norm) &
-    &            bind(C,name="hipblasDznrm2_v2")
+    &            bind(C,name="hipblasDznrm2")
      ! compute result = norm(x) in complex double precision
      use iso_c_binding
      implicit none
@@ -1703,6 +1703,21 @@ module hipFortMap
      ! the current device idx
      integer(c_int),value ::  device_idx
    end function cf_resetFlag
+
+   ! cf_releaseDev - release the GPU gate so other processes can hook on
+   subroutine cf_releaseDev(device_idx) &
+    &              bind(C, name="cf_releaseDev")
+     use iso_c_binding
+     implicit none
+     integer(c_int), value :: device_idx
+   end subroutine cf_releaseDev
+
+   ! cf_cleanupLock - cleanup shared memory lock on program exit
+   subroutine cf_cleanupLock() &
+    &              bind(C, name="cf_cleanupLock")
+     use iso_c_binding
+     implicit none
+   end subroutine cf_cleanupLock
 
    end interface  
 

--- a/f90/3D_MT/FWD_SP2/kernel_c.cu
+++ b/f90/3D_MT/FWD_SP2/kernel_c.cu
@@ -1,14 +1,9 @@
-#include <new>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <complex.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <unistd.h>
-#include <atomic>
 #if defined(FG) 
 #include <nccl.h>
 #endif
@@ -543,60 +538,7 @@ extern "C" int cf_resetFlag(int dev_idx)
     return 0;
 }
 
-// ============================================================================
-// Shared-memory GPU lock: cross-process atomic occupation flags.
-// Multiple MPI ranks can target the same GPU. This uses a POSIX shared-memory
-// region containing std::atomic<int> flags, one per device index.
-// cf_hookDev() acquires (CAS 0->1), cf_releaseDev() releases (store 0).
-// ============================================================================
-
-static constexpr int LOCK_MAX_DEVICES = 64;
-
-// Raw byte flag at offset 0 — no C++ object lifetime requirements.
-// Used *only* to coordinate who runs placement-new on the atomics.
-struct alignas(64) GpuLock {
-    unsigned char constructed;            // 0 = raw storage, !=0 = atomics live
-    std::atomic<int> initialized;         // cross-process init guard (0->1 CAS)
-    std::atomic<int> occupied[LOCK_MAX_DEVICES];
-};
-
-static GpuLock* g_lock       = nullptr;
-static bool     g_lock_inited = false;
-
-static int init_gpu_lock()
-{
-    const char* name = "/ModEM_gpu_lock";
-    // Try to open existing shared memory segment first
-    int fd = shm_open(name, O_RDWR, 0666);
-    if (fd < 0) {
-        // Doesn't exist -- create it
-        fd = shm_open(name, O_CREAT | O_RDWR, 0666);
-        if (fd < 0) return 1;
-        if (ftruncate(fd, sizeof(GpuLock)) < 0) { close(fd); return 1; }
-    }
-
-    g_lock = static_cast<GpuLock*>(mmap(nullptr, sizeof(GpuLock),
-                                         PROT_READ | PROT_WRITE,
-                                         MAP_SHARED, fd, 0));
-    close(fd);
-    if (g_lock == MAP_FAILED) { g_lock = nullptr; return 1; }
-
-    // Begin object lifetimes once across all processes...
-    if (__atomic_test_and_set(&g_lock->constructed, __ATOMIC_ACQ_REL)) {
-        // we are not the first - just wait...
-    } else {
-        // we are the first - need to construct the atomics in shared memory
-        // begin lifetimes of all std::atomic<int> via placement-new.
-        new (&g_lock->initialized) std::atomic<int>(0);
-        for (int i = 0; i < LOCK_MAX_DEVICES; i++)
-            new (&g_lock->occupied[i]) std::atomic<int>(0);
-    }
-
-    g_lock_inited = true;
-    return 0;
-}
-
-// function called from main fortran program 
+#include "gpu_lock.h"
 extern "C" int cf_hookDev(int dev_idx)
 {
     cudaDeviceProp dev_prop;
@@ -656,16 +598,16 @@ extern "C" int cf_hookDev(int dev_idx)
     // Atomic lock loop: CAS 0->1 to claim the GPU
     while (true)
     {
-        int expected = 0;
+        int expected = DEVICE_FREE;
         if (g_lock->occupied[dev_idx].compare_exchange_strong(
-                expected, 1, std::memory_order_acq_rel))
+                expected, DEVICE_IN_USE, std::memory_order_acq_rel))
 	{
             // CLAIMED -- we are the sole occupant
             // Safety: verify memory is actually available after acquiring lock
             err = cudaMemGetInfo(&freeBytes, &totalBytes);
             if (err != cudaSuccess)
             {
-                g_lock->occupied[dev_idx].store(0, std::memory_order_release);
+                g_lock->occupied[dev_idx].store(DEVICE_FREE, std::memory_order_release);
                 printf("Failed to get usage for device %i: %s\n", dev_idx,
                        cudaGetErrorString(err));
                 goto Error;
@@ -673,7 +615,7 @@ extern "C" int cf_hookDev(int dev_idx)
             err = cudaSetDeviceFlags(cudaDeviceScheduleYield);
 	    if (err != cudaSuccess)
 	    {
-		g_lock->occupied[dev_idx].store(0, std::memory_order_release);
+		g_lock->occupied[dev_idx].store(DEVICE_FREE, std::memory_order_release);
 		printf("Failed to set the device flag %i: %s\n", dev_idx, 
 		       cudaGetErrorString(err));
 		goto Error;
@@ -694,22 +636,3 @@ Error:
     return 1;
 }
 
-// Release the GPU lock so other processes can hook on
-extern "C" void cf_releaseDev(int dev_idx)
-{
-    if (g_lock_inited && g_lock != nullptr &&
-        dev_idx >= 0 && dev_idx < LOCK_MAX_DEVICES)
-    {
-        g_lock->occupied[dev_idx].store(0, std::memory_order_release);
-    }
-}
-
-// Cleanup shared memory on program exit
-extern "C" void cf_cleanupLock()
-{
-    if (g_lock != nullptr && g_lock != MAP_FAILED)
-        munmap(g_lock, sizeof(GpuLock));
-    shm_unlink("/ModEM_gpu_lock");
-    g_lock = nullptr;
-    g_lock_inited = false;
-}

--- a/f90/3D_MT/FWD_SP2/kernel_c.cu
+++ b/f90/3D_MT/FWD_SP2/kernel_c.cu
@@ -4,6 +4,10 @@
 #include <complex.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <atomic>
 #if defined(FG) 
 #include <nccl.h>
 #endif
@@ -163,11 +167,11 @@ __global__ void reduce_real(double *a, double s, const int N)
     }
 }
 
-// function to wait for sometime
-void sleep(int seconds)
+// function to wait for sometime (accepts fractional seconds)
+void isleep(float seconds)
 {
     // Converting time into milli_seconds
-    int milli_seconds = 1000 * seconds;
+    int milli_seconds = int(1000.0 * seconds);
     // Storing start time
     clock_t start_time = clock();
     // looping till required time is not achieved
@@ -526,7 +530,7 @@ extern "C" int cf_resetFlag(int dev_idx)
     }
     else
     {
-        sleep(0.1);
+        isleep(0.05);
         err = cudaSetDeviceFlags(cudaDeviceScheduleYield);
         if (err != cudaSuccess)
         {
@@ -538,6 +542,53 @@ extern "C" int cf_resetFlag(int dev_idx)
     return 0;
 }
 
+// ============================================================================
+// Shared-memory GPU lock: cross-process atomic occupation flags.
+// Multiple MPI ranks can target the same GPU. This uses a POSIX shared-memory
+// region containing std::atomic<int> flags, one per device index.
+// cf_hookDev() acquires (CAS 0->1), cf_releaseDev() releases (store 0).
+// ============================================================================
+
+static constexpr int LOCK_MAX_DEVICES = 64;
+
+struct alignas(64) GpuLock {
+    std::atomic<int> occupied[LOCK_MAX_DEVICES];
+};
+
+static GpuLock* g_lock       = nullptr;
+static bool     g_lock_inited = false;
+
+static int init_gpu_lock()
+{
+    const char* name = "/ModEM_gpu_lock";
+
+    // Try to open existing shared memory segment first
+    int fd = shm_open(name, O_RDWR, 0666);
+    if (fd < 0) {
+        // Doesn't exist -- create it
+        fd = shm_open(name, O_CREAT | O_RDWR, 0666);
+        if (fd < 0) return 1;
+        if (ftruncate(fd, sizeof(GpuLock)) < 0) { close(fd); return 1; }
+    }
+
+    g_lock = static_cast<GpuLock*>(mmap(nullptr, sizeof(GpuLock),
+                                         PROT_READ | PROT_WRITE,
+                                         MAP_SHARED, fd, 0));
+    close(fd);
+    if (g_lock == MAP_FAILED) { g_lock = nullptr; return 1; }
+
+    // Ensure all flags are zero on first creation. Only one process does this.
+    static std::atomic<int> init_guard(0);
+    int expected = 0;
+    if (init_guard.compare_exchange_strong(expected, 1)) {
+        for (int i = 0; i < LOCK_MAX_DEVICES; i++)
+            g_lock->occupied[i].store(0, std::memory_order_relaxed);
+    }
+
+    g_lock_inited = true;
+    return 0;
+}
+
 // function called from main fortran program 
 extern "C" int cf_hookDev(int dev_idx)
 {
@@ -545,9 +596,9 @@ extern "C" int cf_hookDev(int dev_idx)
     cudaError_t err;
     size_t freeBytes, totalBytes, usedBytes;
     int nDevices;
-    unsigned int flag = 0;
     double memusage;
      
+    // unsigned int flag = 0;
     // unsigned int i;
     err = cudaGetDeviceCount(&nDevices);
     if (err != cudaSuccess) 
@@ -580,180 +631,77 @@ extern "C" int cf_hookDev(int dev_idx)
 	printf(" WARNING: integrated device found for device: %i ! \n", dev_idx);
 	printf(" this may lead to unsupported computation error...\n");
     }
+    // Init shared-memory lock (note that any rank can trigger)
+    if (!g_lock_inited && init_gpu_lock() != 0)
+    {
+        printf("Error: failed to init GPU lock shared memory\n");
+        goto Error;
+    }
     //now try to hook on to that device
-    err = cudaSetDevice(dev_idx);
-    if (err != cudaSuccess)
-    {
-        printf("Failed to set device %i: %u \n", dev_idx, err);
-        goto Error;
-    }
-    while(true)
-    {
-        // see if this device is available
-        err =  cudaMemGetInfo(&freeBytes, &totalBytes);
-        if (err != cudaSuccess)
-        {
-            printf("Failed to get usage for device %i: %s\n", dev_idx, 
-                cudaGetErrorString(err));
-            goto Error;
-        }
-        usedBytes = totalBytes - freeBytes;
-        memusage = 100.0*usedBytes/totalBytes;
-        // now get some device flags
-        err = cudaGetDeviceFlags(&flag);
-        if (err != cudaSuccess)
-        {
-            printf("Failed to get the device flags %i: %s\n", dev_idx, 
-               cudaGetErrorString(err));
-        }
-        // printf("Dev = %i, flag = %i \n", dev_idx, flag);
-        if (flag != cudaDeviceScheduleYield && memusage < 50)
-        // if (memusage < 50)
-        // if (flag != cudaDeviceScheduleYield)
-        {
-            // If the number of CUDA contexts is greater than the number of 
-            // logical processors in the system, use Spin scheduling. 
-            // Else use Yield scheduling.
-            err = cudaSetDeviceFlags(cudaDeviceScheduleYield);
-            if (err != cudaSuccess)
-            {
-                printf("Failed to set the device flag %i: %s\n", dev_idx, 
-                  cudaGetErrorString(err));
-	    }
-            printf(" # Dev Status  : GPU-mem = %f %%, PCI %i: %i\n", 
-                   memusage, dev_prop.pciBusID, dev_prop.pciDeviceID );
-            break;
-        }
-        // else let it spin
-        sleep(0.02);
-    }
-    printf(" # Dev Selected: %i. %s \n", dev_idx, dev_prop.name);
-    return 0;
-Error:
-    printf("Error: Failed to attach to device: %i \n", dev_idx);
-    return 1;
-}
-/*
-// function called from main fortran program 
-extern "C" int cf_hookCtx(int dev_idx)
-{
-    nvmlReturn_t result;
-    cudaError_t err;
-    CUcontext thisCtx;
-    nvmlDevice_t device;
-    nvmlPciInfo_t pci_bus;
-    nvmlUtilization_t usage;
-    unsigned int Ndevice;
-    // unsigned int i;
-    // unsigned int nProc = 32;
-    // nvmlProcessInfo_t pInfo[nProc];
-    char device_name[NVML_DEVICE_NAME_BUFFER_SIZE];
-
-    // First initialize NVML library
-    result = nvmlInit();
-    if (NVML_SUCCESS != result)
-    { 
-        printf("Failed to initialize NVML: %s\n", nvmlErrorString(result));
-        return 1;
-    }
-    result = nvmlDeviceGetCount(&Ndevice);
-    if (NVML_SUCCESS != result)
-    { 
-        printf("Failed to initialize NVML: %s\n", nvmlErrorString(result));
-        return 1;
-    }
-    if (dev_idx + 1 > Ndevice) 
-    { 
-        printf("Error: not enough devices detected \n");
-        printf("required device idx = %i, Ndevice = %u \n", dev_idx, Ndevice);
-        goto Error;
-    }
     err = cudaSetDevice(dev_idx);
 	if( err != cudaSuccess )
     {
         printf("Failed to set device %i: %u \n", dev_idx, err);
         goto Error;
     }
-    while(true)
+
+    // Atomic lock loop: CAS 0->1 to claim the GPU
+    while (true)
     {
-        // Query for device handle to perform operations on a device
-        // You can also query device handle by other features like:
-        // nvmlDeviceGetHandleBySerial
-        // nvmlDeviceGetHandleByPciBusId
-        result = nvmlDeviceGetHandleByIndex(dev_idx, &device);
-        if (NVML_SUCCESS != result)
-        { 
-            printf("Failed to get handle for device %i: %s\n", dev_idx, nvmlErrorString(result));
-            goto Error;
-        }
-        // now get the current context (if any)
-        cuCtxGetCurrent(&thisCtx);
-        if(thisCtx == NULL) // first call to this device
-        {
-            cuCtxCreate(&thisCtx, 0, dev_idx);
-            result = nvmlDeviceGetName(device, device_name, NVML_DEVICE_NAME_BUFFER_SIZE);
-            if (NVML_SUCCESS != result)
-            { 
-                printf("Failed to get name of device %i: %s\n", dev_idx, nvmlErrorString(result));
-                goto Error;
-            }
-            // pci.busId is very useful to know which device physically 
-            // you're talking to
-            // Using PCI identifier you can also match nvmlDevice 
-            // handle to CUDA device.
-            result = nvmlDeviceGetPciInfo(device, &pci_bus);
-            if (NVML_SUCCESS != result)
-            { 
-                printf("Failed to get pci info for device %i: %s\n", dev_idx, nvmlErrorString(result));
-                goto Error;
-            }
-            break;// just go ahead to initialize the case
-        }
-        else// see if this device is available
-        {
-            cuCtxSetCurrent(thisCtx);
-            result = nvmlDeviceGetUtilizationRates( device, &usage );
-            if (NVML_SUCCESS != result)
+        int expected = 0;
+        if (g_lock->occupied[dev_idx].compare_exchange_strong(
+                expected, 1, std::memory_order_acq_rel))
+	{
+            // CLAIMED -- we are the sole occupant
+            // Safety: verify memory is actually available after acquiring lock
+            err = cudaMemGetInfo(&freeBytes, &totalBytes);
+            if (err != cudaSuccess)
             {
-                printf("Failed to get usage for device %i: %s\n", dev_idx, nvmlErrorString(result));
+                g_lock->occupied[dev_idx].store(0, std::memory_order_release);
+                printf("Failed to get usage for device %i: %s\n", dev_idx,
+                       cudaGetErrorString(err));
                 goto Error;
             }
-            if (usage.memory+usage.gpu < 15)
-            {
-                printf(" # Dev Status  : GPU-util=%u GPU-mem=%u \n", usage.gpu, usage.memory );
-                result = nvmlDeviceGetName(device, device_name, NVML_DEVICE_NAME_BUFFER_SIZE);
-                if (NVML_SUCCESS != result)
-                { 
-                    printf("Failed to get name of device %i: %s\n", dev_idx, nvmlErrorString(result));
-                    goto Error;
-                }
-                // pci.busId is very useful to know which device physically 
-                // you're talking to
-                // Using PCI identifier you can also match nvmlDevice 
-                // handle to CUDA device.
-                result = nvmlDeviceGetPciInfo(device, &pci_bus);
-                if (NVML_SUCCESS != result)
-                { 
-                    printf("Failed to get pci info for device %i: %s\n", dev_idx, nvmlErrorString(result));
-                    goto Error;
-                }
-                break;
-            }
+            err = cudaSetDeviceFlags(cudaDeviceScheduleYield);
+	    if (err != cudaSuccess)
+	    {
+		g_lock->occupied[dev_idx].store(0, std::memory_order_release);
+		printf("Failed to set the device flag %i: %s\n", dev_idx, 
+		       cudaGetErrorString(err));
+		goto Error;
+	    }
+            printf(" # Dev Selected: %i. %s \n", dev_idx, dev_prop.name);
+	    // just calculate the memory usage and report it 
+            usedBytes = totalBytes - freeBytes;
+            memusage = 100.0*usedBytes/totalBytes;
+            printf(" # Dev Status  : GPU-mem = %f %%, PCI %i: %i\n", 
+                   memusage, dev_prop.pciBusID, dev_prop.pciDeviceID );
+	    return 0;
         }
+        // else let it spin
         sleep(0.05);
     }
-    printf(" # Dev Selected:  %i. %s [%s]\n", dev_idx, device_name, pci_bus.busId);
-    result = nvmlShutdown();
-    if (NVML_SUCCESS != result)
-        printf("Failed to shutdown NVML: %s\n", nvmlErrorString(result));
-
-    return 0;
 Error:
-    result = nvmlShutdown();
-    if (NVML_SUCCESS != result)
-        printf("Failed to shutdown NVML: %s\n", nvmlErrorString(result));
-
+    printf("Error: Failed to attach to device: %i \n", dev_idx);
     return 1;
 }
-*/
 
+// Release the GPU lock so other processes can hook on
+extern "C" void cf_releaseDev(int dev_idx)
+{
+    if (g_lock_inited && g_lock != nullptr &&
+        dev_idx >= 0 && dev_idx < LOCK_MAX_DEVICES)
+    {
+        g_lock->occupied[dev_idx].store(0, std::memory_order_release);
+    }
+}
+
+// Cleanup shared memory on program exit
+extern "C" void cf_cleanupLock()
+{
+    if (g_lock != nullptr && g_lock != MAP_FAILED)
+        munmap(g_lock, sizeof(GpuLock));
+    shm_unlink("/ModEM_gpu_lock");
+    g_lock = nullptr;
+    g_lock_inited = false;
+}

--- a/f90/3D_MT/FWD_SP2/kernel_c.cu
+++ b/f90/3D_MT/FWD_SP2/kernel_c.cu
@@ -1,3 +1,4 @@
+#include <new>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -551,7 +552,11 @@ extern "C" int cf_resetFlag(int dev_idx)
 
 static constexpr int LOCK_MAX_DEVICES = 64;
 
+// Raw byte flag at offset 0 — no C++ object lifetime requirements.
+// Used *only* to coordinate who runs placement-new on the atomics.
 struct alignas(64) GpuLock {
+    unsigned char constructed;            // 0 = raw storage, !=0 = atomics live
+    std::atomic<int> initialized;         // cross-process init guard (0->1 CAS)
     std::atomic<int> occupied[LOCK_MAX_DEVICES];
 };
 
@@ -561,7 +566,6 @@ static bool     g_lock_inited = false;
 static int init_gpu_lock()
 {
     const char* name = "/ModEM_gpu_lock";
-
     // Try to open existing shared memory segment first
     int fd = shm_open(name, O_RDWR, 0666);
     if (fd < 0) {
@@ -577,12 +581,15 @@ static int init_gpu_lock()
     close(fd);
     if (g_lock == MAP_FAILED) { g_lock = nullptr; return 1; }
 
-    // Ensure all flags are zero on first creation. Only one process does this.
-    static std::atomic<int> init_guard(0);
-    int expected = 0;
-    if (init_guard.compare_exchange_strong(expected, 1)) {
+    // Begin object lifetimes once across all processes...
+    if (__atomic_test_and_set(&g_lock->constructed, __ATOMIC_ACQ_REL)) {
+        // we are not the first - just wait...
+    } else {
+        // we are the first - need to construct the atomics in shared memory
+        // begin lifetimes of all std::atomic<int> via placement-new.
+        new (&g_lock->initialized) std::atomic<int>(0);
         for (int i = 0; i < LOCK_MAX_DEVICES; i++)
-            g_lock->occupied[i].store(0, std::memory_order_relaxed);
+            new (&g_lock->occupied[i]) std::atomic<int>(0);
     }
 
     g_lock_inited = true;
@@ -606,11 +613,12 @@ extern "C" int cf_hookDev(int dev_idx)
         printf("Error: Failed to inquire the number of devices %s\n", cudaGetErrorString(err));
         return 1;
     }
-    // see the number of devices
-    if (dev_idx + 1 > nDevices) 
-    { 
+    // Validate dev_idx before any lock or CUDA access:
+    if (dev_idx < 0 || dev_idx >= nDevices || dev_idx >= LOCK_MAX_DEVICES)
+    {
         printf("Error: device idx out of range! \n");
-        printf(" inquired device idx = %i, nDevices = %u \n", dev_idx, nDevices);
+        printf(" inquired device idx = %i, nDevices = %d, LOCK_MAX_DEVICES = %d \n",
+               dev_idx, nDevices, LOCK_MAX_DEVICES);
         goto Error;
     }
     err = cudaGetDeviceProperties(&dev_prop, dev_idx);
@@ -679,7 +687,7 @@ extern "C" int cf_hookDev(int dev_idx)
 	    return 0;
         }
         // else let it spin
-        sleep(0.05);
+        isleep(0.05);
     }
 Error:
     printf("Error: Failed to attach to device: %i \n", dev_idx);

--- a/f90/3D_MT/FWD_SP2/kernel_c.hip
+++ b/f90/3D_MT/FWD_SP2/kernel_c.hip
@@ -1,3 +1,4 @@
+#include <new>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -562,7 +563,11 @@ extern "C" int cf_resetFlag(int dev_idx)
 
 static constexpr int LOCK_MAX_DEVICES = 64;
 
+// Raw byte flag at offset 0 — no C++ object lifetime requirements.
+// Used *only* to coordinate who runs placement-new on the atomics.
 struct alignas(64) GpuLock {
+    unsigned char constructed;            // 0 = raw storage, !=0 = atomics live
+    std::atomic<int> initialized;         // cross-process init guard (0->1 CAS)
     std::atomic<int> occupied[LOCK_MAX_DEVICES];
 };
 
@@ -575,6 +580,7 @@ static int init_gpu_lock()
 
     int fd = shm_open(name, O_RDWR, 0666);
     if (fd < 0) {
+        // Doesn't exist -- create it
         fd = shm_open(name, O_CREAT | O_RDWR, 0666);
         if (fd < 0) return 1;
         if (ftruncate(fd, sizeof(GpuLock)) < 0) { close(fd); return 1; }
@@ -586,11 +592,15 @@ static int init_gpu_lock()
     close(fd);
     if (g_lock == MAP_FAILED) { g_lock = nullptr; return 1; }
 
-    static std::atomic<int> init_guard(0);
-    int expected = 0;
-    if (init_guard.compare_exchange_strong(expected, 1)) {
+    // Begin object lifetimes once across all processes...
+    if (__atomic_test_and_set(&g_lock->constructed, __ATOMIC_ACQ_REL)) {
+        // we are not the first - just wait...
+    } else {
+        // we are the first - need to construct the atomics in shared memory
+        // begin lifetimes of all std::atomic<int> via placement-new.
+        new (&g_lock->initialized) std::atomic<int>(0);
         for (int i = 0; i < LOCK_MAX_DEVICES; i++)
-            g_lock->occupied[i].store(0, std::memory_order_relaxed);
+            new (&g_lock->occupied[i]) std::atomic<int>(0);
     }
 
     g_lock_inited = true;
@@ -615,10 +625,11 @@ extern "C" int cf_hookDev(int dev_idx)
         printf("Error: Failed to inquire the number of devices %s\n", hipGetErrorString(err));
         return 1;
     }
-    // see if we have enough number of device
-    if (dev_idx + 1 > nDevices) 
-    { 
-        printf(" inquired device idx = %i, nDevices = %i \n", dev_idx, nDevices);
+    // Validate dev_idx before any lock or HIP access:
+    if (dev_idx < 0 || dev_idx >= nDevices || dev_idx >= LOCK_MAX_DEVICES)
+    {
+        printf(" inquired device idx = %i, nDevices = %d, LOCK_MAX_DEVICES = %d \n",
+               dev_idx, nDevices, LOCK_MAX_DEVICES);
         printf(" Error: device idx out of range! \n");
         goto Error;
     }

--- a/f90/3D_MT/FWD_SP2/kernel_c.hip
+++ b/f90/3D_MT/FWD_SP2/kernel_c.hip
@@ -4,6 +4,10 @@
 #include <string.h>
 #include <complex.h>
 #include "hip/hip_runtime.h"
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <atomic>
 #if defined(FG)
 #include "hip/rccl.h"
 #endif
@@ -164,17 +168,17 @@ __global__ void reduce_real(double *a, double s, const int N)
     }
 }
 
-// function to wait for sometime
-void sleep(float seconds)
-{
+// function to wait for sometime (accepts fractional seconds)
+void isleep(float seconds)
+{   
     // Converting time into milli_seconds
-    int milli_seconds = 1000 * seconds;
-    // Storing start time
+    int milli_seconds = int(1000.0 * seconds);
+    // Storing start time 
     clock_t start_time = clock();
     // looping till required time is not achieved
     while (clock() < start_time + milli_seconds)
         ;
-}
+} 
 
 // function called from main fortran program
 // single to double conversion
@@ -538,7 +542,7 @@ extern "C" int cf_resetFlag(int dev_idx)
     }
     else
     {
-        sleep(0.1);
+        isleep(0.05);
         err = hipSetDeviceFlags(hipDeviceScheduleYield);
         if (err != hipSuccess)
         {
@@ -550,16 +554,60 @@ extern "C" int cf_resetFlag(int dev_idx)
     return 0;
 }
 
-// function called from main fortran program 
+// ============================================================================
+// Shared-memory GPU lock: cross-process atomic occupation flags.
+// Identical logic to CUDA version
+// cf_hookDev() acquires (CAS 0->1), cf_releaseDev() releases (set to 0).
+// ============================================================================
+
+static constexpr int LOCK_MAX_DEVICES = 64;
+
+struct alignas(64) GpuLock {
+    std::atomic<int> occupied[LOCK_MAX_DEVICES];
+};
+
+static GpuLock* g_lock       = nullptr;
+static bool     g_lock_inited = false;
+
+static int init_gpu_lock()
+{
+    const char* name = "/ModEM_gpu_lock";
+
+    int fd = shm_open(name, O_RDWR, 0666);
+    if (fd < 0) {
+        fd = shm_open(name, O_CREAT | O_RDWR, 0666);
+        if (fd < 0) return 1;
+        if (ftruncate(fd, sizeof(GpuLock)) < 0) { close(fd); return 1; }
+    }
+
+    g_lock = static_cast<GpuLock*>(mmap(nullptr, sizeof(GpuLock),
+                                         PROT_READ | PROT_WRITE,
+                                         MAP_SHARED, fd, 0));
+    close(fd);
+    if (g_lock == MAP_FAILED) { g_lock = nullptr; return 1; }
+
+    static std::atomic<int> init_guard(0);
+    int expected = 0;
+    if (init_guard.compare_exchange_strong(expected, 1)) {
+        for (int i = 0; i < LOCK_MAX_DEVICES; i++)
+            g_lock->occupied[i].store(0, std::memory_order_relaxed);
+    }
+
+    g_lock_inited = true;
+    return 0;
+}
+
+// function called from main fortran program, this is different from the original cuda version
+// as we do not have nvml in hip, we will just use the hip api to check the free memory after claiming the lock
 extern "C" int cf_hookDev(int dev_idx)
 {
     hipDeviceProp_t dev_prop;
     hipError_t err;
     size_t freeBytes, totalBytes, usedBytes;
     int nDevices;
-    unsigned int flag = 0;
     double memusage;
      
+    // unsigned int flag = 0;
     // unsigned int i;
     err = hipGetDeviceCount(&nDevices);
     if (err != hipSuccess) 
@@ -597,58 +645,80 @@ extern "C" int cf_hookDev(int dev_idx)
 	printf(" WARNING: integrated device found for device: %i ! \n", dev_idx);
 	printf(" this may lead to unsupported computation error...\n");
     }
-    //now try to hook on to that device
+    // Init shared-memory lock (note that any rank can trigger)
+    if (!g_lock_inited && init_gpu_lock() != 0)
+    {
+        printf("Error: failed to init GPU lock shared memory\n");
+        goto Error;
+    }
+    // set the device context before claiming the lock.
     err = hipSetDevice(dev_idx);
     if (err != hipSuccess)
     {
         printf("Failed to set device %i: %u \n", dev_idx, err);
-        goto Error;
+        return 1;
     }
+
     // now try to get affiliated device
-    while(true)
+    // Atomic lock loop: CAS 0->1 to claim the GPU
+    while (true)
     {
-        // try to get some info for the device
-        err =  hipMemGetInfo(&freeBytes, &totalBytes);
-        if (err != hipSuccess)
+        int expected = 0;
+        if (g_lock->occupied[dev_idx].compare_exchange_strong(
+                expected, 1, std::memory_order_acq_rel))
         {
-            printf("Failed to get usage for device %i: %s\n", dev_idx, 
-                hipGetErrorString(err));
-            goto Error;
-        }
-        usedBytes = totalBytes - freeBytes;
-        memusage = 100.0*usedBytes/totalBytes;
-        // now get some device flags
-        err = hipGetDeviceFlags(&flag);
-        if (err != hipSuccess)
-        {
-            printf("Failed to get the device flags %i: %s\n", dev_idx, 
-               hipGetErrorString(err));
-        }
-        // printf("Dev = %i, flag = %i \n", dev_idx, flag);
-        if (flag != hipDeviceScheduleYield && memusage < 50)
-        // if (memusage < 50)
-        // if (flag != hipDeviceScheduleYield)
-        {
-            // If the number of HIP contexts is greater than the number of 
-            // logical processors in the system, use Spin scheduling. 
-            // Else use Yield scheduling.
-            err = hipSetDeviceFlags(hipDeviceScheduleYield);
+            // CLAIMED -- we are the sole occupant
+            // Safety: verify memory is actually available after acquiring lock
+            err = hipMemGetInfo(&freeBytes, &totalBytes);
             if (err != hipSuccess)
             {
-                printf("Failed to set the device flag %i: %s\n", dev_idx, 
-                  hipGetErrorString(err));
+                g_lock->occupied[dev_idx].store(0, std::memory_order_release);
+                printf("Failed to get usage for device %i: %s\n", dev_idx,
+                       hipGetErrorString(err));
+                goto Error;
+            }
+            err = hipSetDeviceFlags(hipDeviceScheduleYield);
+	    if (err != hipSuccess)
+	    {
+		g_lock->occupied[dev_idx].store(0, std::memory_order_release);
+		printf("Failed to set the device flag %i: %s\n", dev_idx, 
+		       hipGetErrorString(err));
+		goto Error;
 	    }
-            printf(" # Dev Status  : GPU-mem = %f %%, PCI %i: %i\n", 
+            printf(" # Dev Selected: %i. %s \n", dev_idx, dev_prop.name);
+	    // unlike the cuda version, we do not have the nvml to report the GPU memory usage
+	    // just calculate the used memory percentage and report that
+            usedBytes = totalBytes - freeBytes;
+            memusage = 100.0*usedBytes/totalBytes;
+            printf(" # Dev Status  : GPU-mem = %5.2f %%, PCI %i: %i\n", 
                    memusage, dev_prop.pciBusID, dev_prop.pciDeviceID );
-            break;
+            return 0;
         }
         // else let it spin
-        sleep(0.05);
+        isleep(0.05);
     }
-    printf(" # Dev Selected: %i. %s \n", dev_idx, dev_prop.name);
-    return 0;
 Error:
     printf("Error: Failed to attach to device: %i \n", dev_idx);
     return 1;
+}
+
+// Release the GPU lock so other processes can hook on
+extern "C" void cf_releaseDev(int dev_idx)
+{
+    if (g_lock_inited && g_lock != nullptr &&
+        dev_idx >= 0 && dev_idx < LOCK_MAX_DEVICES)
+    {
+        g_lock->occupied[dev_idx].store(0, std::memory_order_release);
+    }
+}
+
+// Cleanup shared memory on program exit
+extern "C" void cf_cleanupLock()
+{
+    if (g_lock != nullptr && g_lock != MAP_FAILED)
+        munmap(g_lock, sizeof(GpuLock));
+    shm_unlink("/ModEM_gpu_lock");
+    g_lock = nullptr;
+    g_lock_inited = false;
 }
 

--- a/f90/3D_MT/FWD_SP2/kernel_c.hip
+++ b/f90/3D_MT/FWD_SP2/kernel_c.hip
@@ -1,14 +1,9 @@
-#include <new>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
 #include <complex.h>
 #include "hip/hip_runtime.h"
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <unistd.h>
-#include <atomic>
 #if defined(FG)
 #include "hip/rccl.h"
 #endif
@@ -555,57 +550,7 @@ extern "C" int cf_resetFlag(int dev_idx)
     return 0;
 }
 
-// ============================================================================
-// Shared-memory GPU lock: cross-process atomic occupation flags.
-// Identical logic to CUDA version
-// cf_hookDev() acquires (CAS 0->1), cf_releaseDev() releases (set to 0).
-// ============================================================================
-
-static constexpr int LOCK_MAX_DEVICES = 64;
-
-// Raw byte flag at offset 0 — no C++ object lifetime requirements.
-// Used *only* to coordinate who runs placement-new on the atomics.
-struct alignas(64) GpuLock {
-    unsigned char constructed;            // 0 = raw storage, !=0 = atomics live
-    std::atomic<int> initialized;         // cross-process init guard (0->1 CAS)
-    std::atomic<int> occupied[LOCK_MAX_DEVICES];
-};
-
-static GpuLock* g_lock       = nullptr;
-static bool     g_lock_inited = false;
-
-static int init_gpu_lock()
-{
-    const char* name = "/ModEM_gpu_lock";
-
-    int fd = shm_open(name, O_RDWR, 0666);
-    if (fd < 0) {
-        // Doesn't exist -- create it
-        fd = shm_open(name, O_CREAT | O_RDWR, 0666);
-        if (fd < 0) return 1;
-        if (ftruncate(fd, sizeof(GpuLock)) < 0) { close(fd); return 1; }
-    }
-
-    g_lock = static_cast<GpuLock*>(mmap(nullptr, sizeof(GpuLock),
-                                         PROT_READ | PROT_WRITE,
-                                         MAP_SHARED, fd, 0));
-    close(fd);
-    if (g_lock == MAP_FAILED) { g_lock = nullptr; return 1; }
-
-    // Begin object lifetimes once across all processes...
-    if (__atomic_test_and_set(&g_lock->constructed, __ATOMIC_ACQ_REL)) {
-        // we are not the first - just wait...
-    } else {
-        // we are the first - need to construct the atomics in shared memory
-        // begin lifetimes of all std::atomic<int> via placement-new.
-        new (&g_lock->initialized) std::atomic<int>(0);
-        for (int i = 0; i < LOCK_MAX_DEVICES; i++)
-            new (&g_lock->occupied[i]) std::atomic<int>(0);
-    }
-
-    g_lock_inited = true;
-    return 0;
-}
+#include "gpu_lock.h"
 
 // function called from main fortran program, this is different from the original cuda version
 // as we do not have nvml in hip, we will just use the hip api to check the free memory after claiming the lock
@@ -674,16 +619,16 @@ extern "C" int cf_hookDev(int dev_idx)
     // Atomic lock loop: CAS 0->1 to claim the GPU
     while (true)
     {
-        int expected = 0;
+        int expected = DEVICE_FREE;
         if (g_lock->occupied[dev_idx].compare_exchange_strong(
-                expected, 1, std::memory_order_acq_rel))
+                expected, DEVICE_IN_USE, std::memory_order_acq_rel))
         {
             // CLAIMED -- we are the sole occupant
             // Safety: verify memory is actually available after acquiring lock
             err = hipMemGetInfo(&freeBytes, &totalBytes);
             if (err != hipSuccess)
             {
-                g_lock->occupied[dev_idx].store(0, std::memory_order_release);
+                g_lock->occupied[dev_idx].store(DEVICE_FREE, std::memory_order_release);
                 printf("Failed to get usage for device %i: %s\n", dev_idx,
                        hipGetErrorString(err));
                 goto Error;
@@ -691,7 +636,7 @@ extern "C" int cf_hookDev(int dev_idx)
             err = hipSetDeviceFlags(hipDeviceScheduleYield);
 	    if (err != hipSuccess)
 	    {
-		g_lock->occupied[dev_idx].store(0, std::memory_order_release);
+		g_lock->occupied[dev_idx].store(DEVICE_FREE, std::memory_order_release);
 		printf("Failed to set the device flag %i: %s\n", dev_idx, 
 		       hipGetErrorString(err));
 		goto Error;
@@ -712,24 +657,3 @@ Error:
     printf("Error: Failed to attach to device: %i \n", dev_idx);
     return 1;
 }
-
-// Release the GPU lock so other processes can hook on
-extern "C" void cf_releaseDev(int dev_idx)
-{
-    if (g_lock_inited && g_lock != nullptr &&
-        dev_idx >= 0 && dev_idx < LOCK_MAX_DEVICES)
-    {
-        g_lock->occupied[dev_idx].store(0, std::memory_order_release);
-    }
-}
-
-// Cleanup shared memory on program exit
-extern "C" void cf_cleanupLock()
-{
-    if (g_lock != nullptr && g_lock != MAP_FAILED)
-        munmap(g_lock, sizeof(GpuLock));
-    shm_unlink("/ModEM_gpu_lock");
-    g_lock = nullptr;
-    g_lock_inited = false;
-}
-


### PR DESCRIPTION
f90/3D_MT/FWD_SP2/EMsolve3D.f90
f90/3D_MT/FWD_SP2/cudaFortMap.f90
f90/3D_MT/FWD_SP2/hipFortMap.f90
f90/3D_MT/FWD_SP2/kernel_c.cu
f90/3D_MT/FWD_SP2/kernel_c.hip

Replace the heuristic flag-based GPU device contention mechanism with a (slightly) more proper atomic lock using POSIX shared memory (shm_open/mmap). The previous method has a potential risk of getting into a race condition (multiple processes hook onto a same GPU device at the same time). While this is fine with modern GPUs (have the 'MPS" feature and allow for multiple processes on one physical GPU), this could cause a problem when multiple processes allocate large chunks of VRAM at the same time, leading to out-of-memory errors.

For now, multiple MPI ranks should be able to safely target and share a same GPU:

- cf_hookDev() acquires GPU via CAS 0->1 on an atomic flag array
- cf_releaseDev() releases the lock so other processes can attach
- cf_cleanupLock() unmaps and unlinks shared memory on exit
- Added corresponding Fortran C-bindings for both CUDA and HIP
- Call cf_releaseDev() from EMsolve3D.f90 after solver completion

also:
- Renamed hipBLAS bindings to remove deprecated _v2 suffix
- Renamed local sleep() to isleep() to avoid POSIX name collision

Tested on both CUDA (12.4) and HIP (7.2.0) environments. 