### PR TITLE
Add ability to compile the HDF5 code in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(ModEM VERSION 0
 enable_language(Fortran)
 
 option(BUILD_MPI "Build MPI version of MPI" ON)
+option(BUILD_HDF5 "Build with HDF5" OFF)
 option(FG "Build the Fine-Grained ModEM Version - (Only compatiable with SP2)" OFF)
 option(USE_C_TIMERS "Use the C timers in ModEM_timers" OFF)
 
@@ -21,13 +22,14 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
+
 set(SUPPORTED_FORWARD_FORMULATIONS "MF;SP;SP2")
 set(SUPPORTED_MODEM_DIMS "2D;3D")
 set(SUPPORTED_GPU_OPTS "off;OFF;CUDA;HIP")
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 
-if (USE_C_TIMERS)
+if (USE_C_TIMERS OR BUILD_HDF5)
         enable_language(C)
 endif()
 
@@ -74,6 +76,10 @@ if (BUILD_MPI)
         add_compile_definitions(MPI)
 endif()
 
+if (BUILD_HDF5)
+        add_compile_definitions(HDF5)
+endif()
+
 if (BUILD_GPU STREQUAL "CUDA")
         add_compile_definitions(CUDA)
 elseif (BUILD_GPU STREQUAL "HIP")
@@ -83,6 +89,7 @@ endif()
 if (FG)
         add_compile_definitions(FG)
 endif()
+
 
 # Source Code
 add_subdirectory(f90)

--- a/f90/3D_MT/CMakeLists.txt
+++ b/f90/3D_MT/CMakeLists.txt
@@ -21,8 +21,6 @@ add_subdirectory(modelParam)
 
 target_sources(${MODEM_EXE} 
     PRIVATE DataFunc.f90
-    #PRIVATE DataIO_HDF5.f90 
-    PRIVATE DataIO.f90
     PRIVATE EMfieldInterp.f90
     PRIVATE ForwardSolver.f90
     PRIVATE GridCalc.f90
@@ -38,5 +36,15 @@ target_sources(${MODEM_EXE}
 if(BUILD_MPI)
     target_sources(${MODEM_EXE}
         PRIVATE Sub_MPI.f90
+    )
+endif()
+
+if(BUILD_HDF5)
+    target_sources(${MODEM_EXE}
+        PRIVATE DataIO_HDF5.f90
+    )
+else()
+    target_sources(${MODEM_EXE}
+        PRIVATE DataIO.f90
     )
 endif()

--- a/f90/3D_MT/ioMod/CMakeLists.txt
+++ b/f90/3D_MT/ioMod/CMakeLists.txt
@@ -1,7 +1,11 @@
 # f90/3D_MT/ioMod CMakeLists.txt
 
-target_sources(${MODEM_EXE}
-    PRIVATE ioAscii.f90
-    #PRIVATE ioBinary.f90
-    #PRIVATE ioHDF5.f90
-)
+if (BUILD_HDF5)
+    target_sources(${MODEM_EXE}
+        PRIVATE ioHDF5.f90
+    )
+else()
+    target_sources(${MODEM_EXE}
+        PRIVATE ioAscii.f90
+    )
+endif()

--- a/f90/CMakeLists.txt
+++ b/f90/CMakeLists.txt
@@ -101,3 +101,8 @@ if (BUILD_GPU STREQUAL "CUDA")
 elseif (BUILD_GPU STREQUAL "HIP")
     target_link_libraries(${MODEM_EXE} PRIVATE "-lamdhip64 -lhipblas -lhipsparse -lstdc++")
 endif()
+
+if (BUILD_HDF5)
+    find_package(HDF5 REQUIRED COMPONENTS Fortran)
+    target_link_libraries(${MODEM_EXE} PRIVATE hdf5::hdf5_fortran)
+endif()


### PR DESCRIPTION
This commit updates the CMake built system to compile the HDF5 Input and output routine to ModEM.

The HDF5 routines seem to work, but I don't have an example HDF5 model file, just a data file. Soon we will add some support to convert ASCII input into HDF5 output and vica-versa.