### PR TITLE
Allow for `mpiifx` in CMakeLists.txt

### DIFF
--- a/f90/CMakeLists.txt
+++ b/f90/CMakeLists.txt
@@ -29,7 +29,7 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
         $<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:DEBUG>>:-fbacktrace>
         $<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:DEBUG>>:-fbounds-check>
     )
-elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel" OR CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
     enable_language(C)
     find_library(MKL_INTEL_LP64 mkl_intel_lp64 HINTS $ENV{MKLROOT}/lib/intel64 ...)
     find_library(MKL_INTEL_THREAD mkl_intel_thread HINTS $ENV{MKLROOT}/lib/intel64 ...)


### PR DESCRIPTION
The new Intel oneAPI compilers (`ifx`, `mpiifx`) have the label IntelLLVM, which currently fails - even though they work perfectly fine. This tiny PR would fix this. Not sure if this is the best way, feel free to change it to a better way.