### PR TITLE
Update CMake error message for unsupported compiler

### DIFF
--- a/f90/CMakeLists.txt
+++ b/f90/CMakeLists.txt
@@ -65,7 +65,10 @@ elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
         -qopenmp
     )
 else()
-    message(FATAL_ERROR "Unknown/Unsupported Fortran Compiler: '${CMAKE_Fortran_COMPILER_ID}' - Supported compilers are < GNU | Ifort")
+    message(FATAL_ERROR
+        "Unknown/Unsupported Fortran Compiler: '${CMAKE_Fortran_COMPILER_ID}'\n"
+        "- Supported compilers are < GNU | ifort (Legacy Intel compiler) | ifx (Intel OneAPI compiler)>\n"
+        "- Of course you will need to specify the MPI wrapper: `-DCMAKE_Fortran_COMPILER=mpifort`")
 endif()
 
 


### PR DESCRIPTION
This commit updates the error message when an unknown or unsupported compiler is passed into the CMake. The hope is to be clearer with what compilers are supported, and tell users how to resolve the error.