### PR TITLE
Introduce an optional namelist to ModEM

### DIFF
--- a/f90/3D_MT/Sub_MPI.f90
+++ b/f90/3D_MT/Sub_MPI.f90
@@ -96,10 +96,10 @@ end subroutine count_number_of_messages_to_RECV
 	implicit none
 	integer Nbytes1,Nbytes2,Nbytes3,Nbytes4
 	!
-	CALL MPI_PACK_SIZE(80*24, MPI_CHARACTER,        MPI_COMM_WORLD, Nbytes1,  ierr)
+	CALL MPI_PACK_SIZE(80*26, MPI_CHARACTER,        MPI_COMM_WORLD, Nbytes1,  ierr)
 	CALL MPI_PACK_SIZE(3,     MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, Nbytes2,  ierr)
 	CALL MPI_PACK_SIZE(2,     MPI_INTEGER,          MPI_COMM_WORLD, Nbytes3,  ierr)
-	CALL MPI_PACK_SIZE(1,     MPI_LOGICAL,          MPI_COMM_WORLD, Nbytes4,  ierr)
+	CALL MPI_PACK_SIZE(2,     MPI_LOGICAL,          MPI_COMM_WORLD, Nbytes4,  ierr)
 	Nbytes=(Nbytes1+Nbytes2+Nbytes3+Nbytes4)+1
 	!
 	if(.not. associated(userdef_control_package)) then
@@ -116,11 +116,12 @@ end subroutine count_number_of_messages_to_RECV
      	type(userdef_control), intent(in)   :: ctrl
         integer index
         index=1
-        call MPI_Pack(ctrl%job,80*24, MPI_CHARACTER, userdef_control_package, Nbytes, index, MPI_COMM_WORLD, ierr)
+        call MPI_Pack(ctrl%job,80*26, MPI_CHARACTER, userdef_control_package, Nbytes, index, MPI_COMM_WORLD, ierr)
         call MPI_Pack(ctrl%lambda,3, MPI_DOUBLE_PRECISION, userdef_control_package, Nbytes, index, MPI_COMM_WORLD, ierr)
         call MPI_Pack(ctrl%CovType,1, MPI_INTEGER, userdef_control_package,  Nbytes, index, MPI_COMM_WORLD, ierr)
         call MPI_Pack(ctrl%output_level,1, MPI_INTEGER, userdef_control_package, Nbytes, index, MPI_COMM_WORLD, ierr)
         call MPI_Pack(ctrl%storeSolnsInFile,1,MPI_LOGICAL, userdef_control_package, Nbytes, index, MPI_COMM_WORLD, ierr)
+        call MPI_Pack(ctrl%SFF,1,MPI_LOGICAL, userdef_control_package, Nbytes, index, MPI_COMM_WORLD, ierr)
 
 end subroutine pack_userdef_control
 
@@ -156,6 +157,10 @@ end subroutine pack_userdef_control
    call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%wFile_EMrhs,80, MPI_CHARACTER,MPI_COMM_WORLD, ierr)
    call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%wFile_Sens,80, MPI_CHARACTER,MPI_COMM_WORLD, ierr)
 
+   ! Primary Field Info
+   call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%primary_field,80, MPI_CHARACTER,MPI_COMM_WORLD, ierr)
+   call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%primary_field_file,80, MPI_CHARACTER,MPI_COMM_WORLD, ierr)
+
    call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%rFile_Cov,80, MPI_CHARACTER,MPI_COMM_WORLD, ierr)
    call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%search,80, MPI_CHARACTER,MPI_COMM_WORLD, ierr)
    call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%option,80, MPI_CHARACTER,MPI_COMM_WORLD, ierr)
@@ -168,31 +173,45 @@ end subroutine pack_userdef_control
    call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%CovType,1, MPI_INTEGER,MPI_COMM_WORLD, ierr)
    call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%output_level,1, MPI_INTEGER,MPI_COMM_WORLD, ierr)
    call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%storeSolnsInFile,1, MPI_LOGICAL,MPI_COMM_WORLD, ierr)
+   call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%SFF,1, MPI_LOGICAL,MPI_COMM_WORLD, ierr)
+
 end subroutine unpack_userdef_control
 
 !********************************************************************
 subroutine check_userdef_control_MPI (which_proc,ctrl)
 
-	type(userdef_control), intent(in)   :: ctrl
-	character(20), intent(in)           :: which_proc
+    type(userdef_control), intent(in)   :: ctrl
+    character(20), intent(in)           :: which_proc
 
-       write(6,*)trim(which_proc),' : ctrl%wFile_Sens ',trim(ctrl%wFile_Sens)
-       write(6,*)trim(which_proc),' : ctrl%lambda ',(ctrl%lambda)
-       write(6,*)trim(which_proc),' : ctrl%eps ',(ctrl%eps)
-       write(6,*)trim(which_proc),' : ctrl%rFile_Cov ',trim(ctrl%rFile_Cov)
-       write(6,*)trim(which_proc),' : ctrl%search ',trim(ctrl%search)
-       write(6,*)trim(which_proc),' : ctrl%CovType ',ctrl%CovType
-       write(6,*)trim(which_proc),' : ctrl%output_level ',ctrl%output_level
-       write(6,*)trim(which_proc),' : ctrl%rFile_Model ',trim(ctrl%rFile_Model)
-       write(6,*)trim(which_proc),' : ctrl%rFile_Data ',trim(ctrl%rFile_Data)
-       write(6,*)trim(which_proc),' : ctrl%rFile_EMsoln ',trim(ctrl%rFile_EMsoln)
-       write(6,*)trim(which_proc),' : ctrl%rFile_fwdCtrl ',trim(ctrl%rFile_fwdCtrl)
-       write(6,*)trim(which_proc),' : ctrl%rFile_invCtrl ',trim(ctrl%rFile_invCtrl)
-       write(6,*)trim(which_proc),' : ctrl%rFile_Config ',trim(ctrl%rFile_Config)
-       write(6,*)trim(which_proc),' : ctrl%rFile_Prior ',trim(ctrl%rFile_Prior)
-       write(6,*)trim(which_proc),' : ctrl%prefix ',trim(ctrl%prefix)
-       write(6,*)trim(which_proc),' : ctrl%storeSolnsInfile ',ctrl%storeSolnsInfile
+    write(6,*)trim(which_proc),' : ctrl%wFile_Sens ',trim(ctrl%wFile_Sens)
+    write(6,*)trim(which_proc),' : ctrl%lambda ',(ctrl%lambda)
+    write(6,*)trim(which_proc),' : ctrl%eps ',(ctrl%eps)
+    write(6,*)trim(which_proc),' : ctrl%rFile_Cov ',trim(ctrl%rFile_Cov)
+    write(6,*)trim(which_proc),' : ctrl%search ',trim(ctrl%search)
+    write(6,*)trim(which_proc),' : ctrl%CovType ',ctrl%CovType
+    write(6,*)trim(which_proc),' : ctrl%output_level ',ctrl%output_level
+    write(6,*)trim(which_proc),' : ctrl%rFile_Model ',trim(ctrl%rFile_Model)
+    write(6,*)trim(which_proc),' : ctrl%rFile_Data ',trim(ctrl%rFile_Data)
+    write(6,*)trim(which_proc),' : ctrl%rFile_EMsoln ',trim(ctrl%rFile_EMsoln)
+    write(6,*)trim(which_proc),' : ctrl%rFile_fwdCtrl ',trim(ctrl%rFile_fwdCtrl)
+    write(6,*)trim(which_proc),' : ctrl%rFile_invCtrl ',trim(ctrl%rFile_invCtrl)
+    write(6,*)trim(which_proc),' : ctrl%rFile_Config ',trim(ctrl%rFile_Config)
+    write(6,*)trim(which_proc),' : ctrl%rFile_Prior ',trim(ctrl%rFile_Prior)
 
+    if (trim(ctrl % primary_field) /= 'n') then ! 'hidden option' only print if it has been set via namelist
+        write(6,*)trim(which_proc),' : ctrl%primary_field',trim(ctrl%primary_field)
+    end if
+
+    if (trim(ctrl % primary_field_file) /= 'n') then ! 'hidden option' only print if it has been set via namelist
+        write(6,*)trim(which_proc),' : ctrl%primary_field_file',trim(ctrl%primary_field_file)
+    end if
+
+    write(6,*)trim(which_proc),' : ctrl%prefix ',trim(ctrl%prefix)
+    write(6,*)trim(which_proc),' : ctrl%storeSolnsInfile ',ctrl%storeSolnsInfile
+
+    if (ctrl%SFF) then ! 'hidden option' only print if it has been set via namelist
+        write(6,*)trim(which_proc),' : ctrl%SFF',ctrl%SFF
+    end if
 
 end subroutine check_userdef_control_MPI
 !********************************************************************

--- a/f90/Mod3DMT.f90
+++ b/f90/Mod3DMT.f90
@@ -58,6 +58,7 @@ program Mod3DMT
       end if
 #else
       call parseArgs('Mod3DMT',cUserDef) ! OR readStartup(rFile_Startup,cUserDef)
+      call process_optional_namelist(cUserDef)
       write(6,*)'I am a SERIAL version'
 #endif
       call initGlobalData(cUserDef)
@@ -420,7 +421,7 @@ program Mod3DMT
        end if
 #endif
      case (GEN_NAMELIST)
-         write(0,*) "Generating the optional namelist: '", trim(MODEM_NAMELIST), "' and quiting.."
+         write(0,*) "Generating the optional namelist: '", trim(MODEM_NAMELIST), "' and quitting.."
          call generate_optional_nml()
 
      case default

--- a/f90/Mod3DMT.f90
+++ b/f90/Mod3DMT.f90
@@ -49,6 +49,7 @@ program Mod3DMT
           call parseArgs('Mod3DMT',cUserDef)  
           ! OR readStartup(rFile_Startup,cUserDef)
           write(6,*)'I am a PARALLEL version'
+          call process_optional_namelist(cUserDef)
           call Master_job_Distribute_userdef_control(cUserDef)
           open(ioMPI,file=cUserDef%wFile_MPI)
           write(ioMPI,*) 'Total Number of nodes= ', number_of_workers
@@ -418,6 +419,9 @@ program Mod3DMT
            call write_dataVectorMTX(allData,cUserDef%wFile_Data)
        end if
 #endif
+     case (GEN_NAMELIST)
+         write(0,*) "Generating the optional namelist: '", trim(MODEM_NAMELIST), "' and quiting.."
+         call generate_optional_nml()
 
      case default
 

--- a/f90/UserCtrl.f90
+++ b/f90/UserCtrl.f90
@@ -19,6 +19,9 @@ module UserCtrl
   character*1, parameter  :: TEST_GRAD = 'g'
   character*1, parameter  :: TEST_ADJ = 'A'
   character*1, parameter  :: TEST_SENS = 'S'
+  character*1, parameter  :: GEN_NAMELIST = 'N'
+
+  character(len=*), parameter :: MODEM_NAMELIST = 'namelist.modem.nl'
 
   ! ***************************************************************************
   ! * userdef_control contains the list of all essential input information currently
@@ -51,6 +54,10 @@ module UserCtrl
 	character(80)       :: wFile_dModel
 	character(80)       :: wFile_EMsoln, wFile_EMrhs, wFile_Sens
 
+    ! Primary Field information
+    character(80)       :: primary_field ! Method for primary field, 'gen', 'file'
+    character(80)       :: primary_field_file
+
 	! Specify covariance configuration
 	character(80)       :: rFile_Cov
 
@@ -60,8 +67,8 @@ module UserCtrl
 	! Choose the sort of test / procedure variant you wish to perform
 	character(80)       :: option
 
-    	! Out-of-core file prefix for storing working E-field solutions (NCI)
-    	character(80)       :: prefix
+    ! Out-of-core file prefix for storing working E-field solutions (NCI)
+    character(80)       :: prefix
 
 	! Specify damping parameter for the inversion
 	real(8)             :: lambda
@@ -72,14 +79,16 @@ module UserCtrl
 	! Specify the magnitude for random perturbations
 	real(8)             :: delta
 
-    	! Specify the Covariance Type used in 3D (reserved for future use)
-    	integer             :: CovType
+    ! Specify the Covariance Type used in 3D (reserved for future use)
+    integer             :: CovType
 
 	! Indicate how much output you want
 	integer             :: output_level
 
-    	! Reduce master memory usage by storing E-fields in files (NCI)
-    	logical             :: storeSolnsInFile
+    ! Reduce master memory usage by storing E-fields in files (NCI)
+    logical             :: storeSolnsInFile
+
+    logical             :: SFF
 
   end type userdef_control
 
@@ -112,22 +121,25 @@ Contains
   	ctrl%rFile_dModel = 'n'
   	ctrl%wFile_dModel = 'n'
   	ctrl%rFile_EMrhs = 'n'
-    	ctrl%wFile_EMrhs = 'n'
-    	ctrl%rFile_EMsoln = 'n'
+    ctrl%wFile_EMrhs = 'n'
+    ctrl%rFile_EMsoln = 'n'
   	ctrl%wFile_EMsoln = 'n'
   	ctrl%rFile_Prior = 'n'
   	ctrl%wFile_Sens = 'n'
   	ctrl%rFile_Cov = 'n'
+    ctrl% primary_field = 'n'
+    ctrl% primary_field_file = 'n'
   	ctrl%search = 'NLCG'
   	ctrl%option = 'J'
   	ctrl%lambda = 10.
   	ctrl%eps = 1.0e-7
   	ctrl%delta = 0.05
-    	! 1 for AR, 2 for L1, 3 for L2
-    	ctrl%CovType = 1
+    ! 1 for AR, 2 for L1, 3 for L2
+    ctrl%CovType = 1
   	ctrl%output_level = 3	
 	ctrl%prefix = 'n'
 	ctrl%storeSolnsInFile = .false.
+    ctrl%SFF = .false.
 
     ! Using process ID in MPI output file name has the advantage that
     ! the user may run several instances of the program in one directory
@@ -838,6 +850,8 @@ Contains
            ctrl%wFile_Sens = temp(6)
         end if
 
+      case (GEN_NAMELIST) ! N - Generate the optional namelist - 'hidden' for now
+          ! NO-OP - Don't need to do anything here...
       case default
          call errStop('Unknown job. Please check your command line options')
 
@@ -850,4 +864,224 @@ Contains
      ctrl%job = job
 
   end subroutine parseArgs
+
+  subroutine generate_optional_nml()
+
+     implicit none
+
+     integer :: nl_fid
+     logical :: namelist_exists
+     character (len=256) :: iomsg
+     integer :: iostat
+
+     inquire(file=trim(MODEM_NAMELIST), exist=namelist_exists)
+     if (namelist_exists) then
+         write(0,*) "Namelist file '", trim(MODEM_NAMELIST), "' already exists"
+         write(0,*) "Delete it and re-run this program to overwrite it"
+         call ModEM_abort()
+     end if
+
+     open(newunit=nl_fid, file=trim(MODEM_NAMELIST), status='new', action='write', iostat=iostat, iomsg=iomsg)
+     if (iostat /= 0) then
+         write(0,*) "Failed to open namelist '", trim(MODEM_NAMELIST), "': ", trim(iomsg)
+         call ModEM_abort()
+     end if
+
+     call gen_nml_section_settings(nl_fid)
+
+     call gen_nml_section_grid(nl_fid)
+
+     close(nl_fid)
+
+  end subroutine generate_optional_nml
+
+  subroutine process_optional_namelist(ctrl)
+
+     implicit none
+     type(userdef_control), intent(inout)   :: ctrl
+
+     logical :: namelist_exists
+     integer :: nl_fid, iostat
+
+     character(len=256) :: iomsg
+
+     inquire(file=trim(MODEM_NAMELIST), exist=namelist_exists)
+
+     if (.not. namelist_exists) then
+         ! The namelist doesn't exist, so set defaults (if there are any)
+         ! and return
+         return
+     end if
+
+     write(0,*) "Optional ModEM namelist: '", trim(MODEM_NAMELIST), "' was found! Reading..."
+
+     open(newunit=nl_fid, file=trim(MODEM_NAMELIST), status='old', action='read', iostat=iostat, iomsg=iomsg)
+     if (iostat /= 0) then
+         write(0,*) "Failed to open namelist '", trim(MODEM_NAMELIST), "': ", trim(iomsg)
+         call ModEM_abort()
+     end if
+
+     ! The following subroutines *attempt* to read a namelist section.
+     ! We should allow namelist sections to appear in any order, and allow the user
+     ! to ommit any undesired sections.
+     !
+     ! So, we should rewind, so ftran can find the section we are asking for.
+     call process_nml_section_settings(ctrl, nl_fid)
+     rewind(nl_fid)
+
+     call process_nml_section_grid(ctrl, nl_fid)
+     rewind(nl_fid) ! Technically not necessary, but just continuing the pattern
+
+     close(nl_fid)
+
+  end subroutine process_optional_namelist
+
+  subroutine process_nml_section_settings(ctrl, nl_fid)
+
+     implicit none
+
+     type (userdef_control), intent(inout) :: ctrl
+     integer, intent(in) :: nl_fid
+
+     integer :: iostat
+     integer :: output_level_int
+
+     ! Namelist - &settings - section
+     character (len=80) :: output_level
+     character (len=256) :: iomsg
+
+
+     namelist /settings/ output_level
+
+
+     read(nl_fid, nml=settings, iostat=iostat, iomsg=iomsg)
+     if (iostat /= 0) then
+        ! Returns true if we have read to the EOF. Meaning that the section was not present (iostat == -1)
+        if (IS_IOSTAT_END(iostat)) then
+             write(0,*) "Optional namelist section '&settings' was not present in ", trim(MODEM_NAMELIST), " skipping..."
+             return
+        end if
+
+        ! Any other error means we have an error with the namelist
+        ! that should be reported to the user
+        write(0,*) "ERROR: Processing namelist section '&settings': ", trim(iomsg)
+        call ModEM_abort()
+     end if
+
+     write(0,*) "Optional namelist section '&settings' was read!"
+
+     ! Process output_level
+     select case (output_level) ! Determine output_level number for comparision in CL arg
+         case ('debug')
+           output_level_int = 5
+         case ('full')
+           output_level_int = 4
+         case ('regular')
+           output_level_int = 3
+         case ('compact')
+           output_level_int = 2
+         case ('result')
+           output_level_int = 1
+         case ('none')
+           output_level_int = 0
+         case default
+           output_level_int = 3
+    end select
+
+    ! Alert the user that we are changing the output level
+    if (output_level_int /= ctrl % output_level) then
+        ! output_level is the same so do nothing...
+        write(0,*) 'WARNING: -V argument is being overriden by optional output_level option in: ', trim(MODEM_NAMELIST)
+        select case (output_level)
+             case ('debug')
+               write(0,*) 'Output all information including debugging lines.'
+               ctrl%output_level = 5
+             case ('full')
+               write(0,*) 'Output full information to screen and to files.'
+               ctrl%output_level = 4
+             case ('regular')
+               write(0,*) 'Output information to files, and progress report to screen (default).'
+               ctrl%output_level = 3
+             case ('compact')
+               write(0,*) 'Output information to files, and compact summary to screen.'
+               ctrl%output_level = 2
+             case ('result')
+               write(0,*) 'Output minimal information to files, and result to screen.'
+               ctrl%output_level = 1
+             case ('none')
+               write(0,*) 'Output nothing at all except result to screen and to files.'
+               ctrl%output_level = 0
+             case default
+               ctrl%output_level = 3
+        end select
+    end if
+
+
+  end subroutine process_nml_section_settings
+
+  subroutine gen_nml_section_settings(nl_fid)
+
+      implicit none
+
+      integer, intent(in) :: nl_fid
+
+      write(nl_fid, *) "&settings"
+      write(nl_fid, *) "    ! 'output_level' below overrides -V passed in on the command line"
+      write(nl_fid, *) "    output_level = 'regular'"
+      write(nl_fid, *) "/"
+
+  end subroutine gen_nml_section_settings
+
+  subroutine process_nml_section_grid(ctrl, nl_fid)
+     implicit none
+
+     type (userdef_control), intent(inout) :: ctrl
+     integer, intent(in) :: nl_fid
+
+     integer :: iostat
+     character (len=256) :: iomsg
+
+     ! Namlist - &grid - section
+     character(len=80) :: primary_field
+     character(len=80) :: primary_field_file
+     logical :: sff
+
+     namelist /grid/ sff, primary_field, primary_field_file
+
+     read(nl_fid, nml=grid, iostat=iostat, iomsg=iomsg)
+     if (iostat /= 0) then
+        ! Returns true if we have read to the EOF. Meaning that the section was not present (iostat == -1)
+        if (IS_IOSTAT_END(iostat)) then 
+             write(0,*) "Optional namelist section '&grid' was not present in ", trim(MODEM_NAMELIST), " skipping..."
+             return
+        end if
+
+        ! Any other error means we have an error with the namelist
+        ! that should be reported to the user
+        write(0,*) "ERROR: Processing namelist section '&grid': ", trim(iomsg)
+        call ModEM_abort()
+     end if
+
+     write(0,*) "Optional namelist section '&grid' was read!"
+
+     ctrl % SFF = sff
+     ctrl % primary_field_file = primary_field_file
+
+  end subroutine process_nml_section_grid
+
+  subroutine gen_nml_section_grid(nl_fid)
+
+      implicit none
+
+      integer :: nl_fid
+
+      write(nl_fid, *) '&grid'
+      write(nl_fid, *) '    SFF = .false.  ! Currently unused'
+      write(nl_fid, *) '    primary_field = "file" ! Currently unused'
+      write(nl_fid, *) '    primary_field_file = "none" ! Currently unused'
+      write(nl_fid, *) '/'
+
+  end subroutine gen_nml_section_grid 
+
+
 end module UserCtrl

--- a/f90/UserCtrl.f90
+++ b/f90/UserCtrl.f90
@@ -888,7 +888,6 @@ Contains
      end if
 
      call gen_nml_section_settings(nl_fid)
-
      call gen_nml_section_grid(nl_fid)
 
      close(nl_fid)
@@ -950,9 +949,9 @@ Contains
      character (len=80) :: output_level
      character (len=256) :: iomsg
 
-
      namelist /settings/ output_level
 
+     output_level = 'regular'
 
      read(nl_fid, nml=settings, iostat=iostat, iomsg=iomsg)
      if (iostat /= 0) then
@@ -990,8 +989,9 @@ Contains
 
     ! Alert the user that we are changing the output level
     if (output_level_int /= ctrl % output_level) then
-        ! output_level is the same so do nothing...
-        write(0,*) 'WARNING: -V argument is being overriden by optional output_level option in: ', trim(MODEM_NAMELIST)
+        ! output_level differs, so override the current setting
+         write(0,*) 'WARNING: output_level from optional namelist overrides current output level (including any -V): ', &
+             trim(MODEM_NAMELIST)
         select case (output_level)
              case ('debug')
                write(0,*) 'Output all information including debugging lines.'
@@ -1015,7 +1015,6 @@ Contains
                ctrl%output_level = 3
         end select
     end if
-
 
   end subroutine process_nml_section_settings
 
@@ -1048,6 +1047,10 @@ Contains
 
      namelist /grid/ sff, primary_field, primary_field_file
 
+     sff = ctrl % SFF
+     primary_field = ctrl % primary_field
+     primary_field_file = ctrl % primary_field_file
+
      read(nl_fid, nml=grid, iostat=iostat, iomsg=iomsg)
      if (iostat /= 0) then
         ! Returns true if we have read to the EOF. Meaning that the section was not present (iostat == -1)
@@ -1065,6 +1068,7 @@ Contains
      write(0,*) "Optional namelist section '&grid' was read!"
 
      ctrl % SFF = sff
+     ctrl % primary_field = primary_field
      ctrl % primary_field_file = primary_field_file
 
   end subroutine process_nml_section_grid


### PR DESCRIPTION
This merge adds an optional namelist to ModEM. The namelist should be a file in the current working directory with the name of: `namelist.modem.nl`.

The namelist is only read if the `namelist.modem.nl` file is found in the CWD otherwise no attempt is made to read it.

The goal for the namelist is to provide an extra location to provide ModEM options that neither fit into the forward control file, or the inversion control file.

So far, the namelist only has one option that alters the execution of ModEM: the `output_level` setting (normally set by -V on the CL). If `output_level` is set in the namelist, the verbose setting will override the default verbose setting or the verbose level passed in through the command line.

There are three other options that can be set in the namelist. These are all under the '&grid' section. These options are: `SFF`, `primary_field`, and `primary_field_file`. At the moment, these options do nothing except set corresponding variables in `userCtrl` data structure. These variables are added here to assist Anna with some of her on-going spherical/secondary field formulation work.

The two namelist sections (`&settings` and `&grid`) are both optional. They can either be completely omitted or written in any order in the file. This provides some great flexibility for the user. It also should be pretty easy for other developers to see how to add a new section.

An example namelist can be generated by using a hidden command line option: `./Mod3DMT -N`. That routine wont create the file if there is a namelist already present. As we use the namelist more, we can consider adding in a help message about `-N`.