### PR TITLE
HOTFIX - Fix cmake error when Spherical was being used if not specified

### DIFF
--- a/f90/3D_MT/CMakeLists.txt
+++ b/f90/3D_MT/CMakeLists.txt
@@ -31,7 +31,7 @@ target_sources(${MODEM_EXE}
     PRIVATE Sub_MPI.f90
 )
 
-if (!BUILD_SPHERICAL)
+if (NOT BUILD_SPHERICAL)
     target_sources(${MODEM_EXE}
         PRIVATE GridCalc.f90
     )

--- a/f90/3D_MT/FWD/CMakeLists.txt
+++ b/f90/3D_MT/FWD/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_subdirectory(Mod2d)
 
-if (!BUILD_SPHERICAL)
+if (NOT BUILD_SPHERICAL)
     target_sources(${MODEM_EXE}
         PRIVATE boundary_ws.f90
     )

--- a/f90/3D_MT/SP_Topology/CMakeLists.txt
+++ b/f90/3D_MT/SP_Topology/CMakeLists.txt
@@ -6,7 +6,7 @@ target_sources(${MODEM_EXE}
     PRIVATE vecTranslate.f90
 )
 
-if (!BUILD_SPHERICAL)
+if (NOT BUILD_SPHERICAL)
     target_sources(${MODEM_EXE}
         PRIVATE MetricElements_CSG.f90
     )


### PR DESCRIPTION
An error was made with the spherical Cmake where `!` was used instead of `NOT`.