### PR TITLE
Feature: new Bi-Helmholtz covariance for mHat domain (CovType=2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,9 @@ if (FG)
         add_compile_definitions(FG)
 endif()
 
+if (FORWARD_FORMULATION STREQUAL "SP" OR FORWARD_FORMULATION STREQUAL "SP2")
+    add_compile_definitions(SP_FORM)
+endif()
 
 # Source Code
 add_subdirectory(f90)

--- a/docs/source/file_formats.rst
+++ b/docs/source/file_formats.rst
@@ -556,54 +556,54 @@ Blocks are repeated as necessary — a single block is used in the simple exampl
 indicating that the regions extend over all 11 layers (top-to-bottom) of this
 very small grid.
 
-Bi-Helmholtz Covariance (CovType=2)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+H2 (Bi-Helmholtz) Covariance (CovType=2)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-ModEM now supports an alternative regularization method based on the new 
-Bi-Helmholtz operator, which provides isotropic smoothing with a (Matérn) 
-covariance structure.
+ModEM now supports an alternative regularization method based on the 
+H2 (Bi-Helmholtz) operator, which provides isotropic smoothing with a 
+(Matérn) covariance structure.
 
-To use Bi-Helmholtz smoothing, set ``CovType=2`` in the inversion control file
+To use H2 smoothing, set ``CovType=2`` in the inversion control file
 or command line, and provide a covariance file in the new unified format.
 
 The unified covariance file format uses line 17 to specify both grid dimensions
 and the CovType:
 
 - **3 values** (``Nx Ny NzEarth``): legacy format, defaults to CovType=1 (AR)
-- **4 values** (``Nx Ny NzEarth 2``): new format, CovType=2 (Bi-Helmholtz)
+- **4 values** (``Nx Ny NzEarth 2``): new format, CovType=2 (H2)
 
 The file structure for CovType=2 is:
 
 .. code-block:: text
 
     Line 17:  Nx Ny NzEarth 2          <-- grid dimensions + CovType
-    Line 18:  Sx(1:NzEarth)             <-- placeholder (not used by Bi-Helmholtz)
-    Line 19:  Sy(1:NzEarth)             <-- placeholder (not used by Bi-Helmholtz)
-    Line 20:  Sz                         <-- placeholder (not used by Bi-Helmholtz)
+    Line 18:  Sx(1:NzEarth)             <-- placeholder (not used by H2)
+    Line 19:  Sy(1:NzEarth)             <-- placeholder (not used by H2)
+    Line 20:  Sz                         <-- placeholder (not used by H2)
     Line 21:  N kappa pcg_tol pcg_maxIt  <-- parameter array
     Line 22:  nrules                     <-- number of exception rules
     Line 23+: mask1 mask2 smoothing      <-- exception rules (3 values per rule)
     Line 24+: mask blocks                <-- same format as CovType=1
 
-The Bi-Helmholtz parameters are:
+The H2 parameters are:
 
 - **kappa**: dimensionless smoothing parameter; correlation length ~ 1/kappa cells
 - **pcg_tol**: PCG solver tolerance (typically 1e-7)
 - **pcg_maxIt**: maximum PCG iterations (typically 250)
-- **N**: number of smoothing passes (typically 1, not used by Bi-Helmholtz)
+- **N**: number of smoothing passes (typically 1, not used by H2)
 
 Example CovType=2 covariance file:
 
 .. code-block:: text
 
     +-----------------------------------------------------------------------------+
-    | This file defines model covariance for the Bi-Helmholtz smoother.           |
+    | This file defines model covariance for the H2 (Bi-Helmholtz) smoother.      |
     | ...                                                                         |
     +-----------------------------------------------------------------------------+
     21 28 11 2   <-- Grid dimensions (Nx, Ny, NzEarth) + covtype
-    0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 <-- Sx, not used by Bi-Helmholtz
-    0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 <-- Sy, not used by Bi-Helmholtz
-    0.1   <-- Sz, not used by Bi-Helmholtz
+    0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 <-- Sx, not used by H2
+    0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 <-- Sy, not used by H2
+    0.1   <-- Sz, not used by H2
 
     1 0.5 1e-7 250 <-- Number of smoothings, kappa, PCG tolerance, max PCG iter
 
@@ -636,7 +636,7 @@ Example CovType=2 covariance file:
     9 9 9 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4
 
 The Sx, Sy, Sz values are placeholders for future extensions and are not used in 
-the current Bi-Helmholtz implementation. Exception rules use the same 3-value 
+the current H2 implementation. Exception rules use the same 3-value 
 format as CovType=1; the third value (smoothing) is read but not used for
 CovType=2 (tears are determined by rule presence).
 

--- a/docs/source/file_formats.rst
+++ b/docs/source/file_formats.rst
@@ -556,6 +556,96 @@ Blocks are repeated as necessary — a single block is used in the simple exampl
 indicating that the regions extend over all 11 layers (top-to-bottom) of this
 very small grid.
 
+Bi-Helmholtz Covariance (CovType=2)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ModEM now supports an alternative regularization method based on the new 
+Bi-Helmholtz operator, which provides isotropic smoothing with a (Matérn) 
+covariance structure.
+
+To use Bi-Helmholtz smoothing, set ``CovType=2`` in the inversion control file
+or command line, and provide a covariance file in the new unified format.
+
+The unified covariance file format uses line 17 to specify both grid dimensions
+and the CovType:
+
+- **3 values** (``Nx Ny NzEarth``): legacy format, defaults to CovType=1 (AR)
+- **4 values** (``Nx Ny NzEarth 2``): new format, CovType=2 (Bi-Helmholtz)
+
+The file structure for CovType=2 is:
+
+.. code-block:: text
+
+    Line 17:  Nx Ny NzEarth 2          <-- grid dimensions + CovType
+    Line 18:  Sx(1:NzEarth)             <-- placeholder (not used by Bi-Helmholtz)
+    Line 19:  Sy(1:NzEarth)             <-- placeholder (not used by Bi-Helmholtz)
+    Line 20:  Sz                         <-- placeholder (not used by Bi-Helmholtz)
+    Line 21:  N kappa pcg_tol pcg_maxIt  <-- parameter array
+    Line 22:  nrules                     <-- number of exception rules
+    Line 23+: mask1 mask2 smoothing      <-- exception rules (3 values per rule)
+    Line 24+: mask blocks                <-- same format as CovType=1
+
+The Bi-Helmholtz parameters are:
+
+- **kappa**: dimensionless smoothing parameter; correlation length ~ 1/kappa cells
+- **pcg_tol**: PCG solver tolerance (typically 1e-7)
+- **pcg_maxIt**: maximum PCG iterations (typically 250)
+- **N**: number of smoothing passes (typically 1, not used by Bi-Helmholtz)
+
+Example CovType=2 covariance file:
+
+.. code-block:: text
+
+    +-----------------------------------------------------------------------------+
+    | This file defines model covariance for the Bi-Helmholtz smoother.           |
+    | ...                                                                         |
+    +-----------------------------------------------------------------------------+
+    21 28 11 2   <-- Grid dimensions (Nx, Ny, NzEarth) + covtype
+    0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 <-- Sx, not used by Bi-Helmholtz
+    0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 <-- Sy, not used by Bi-Helmholtz
+    0.1   <-- Sz, not used by Bi-Helmholtz
+
+    1 0.5 1e-7 250 <-- Number of smoothings, kappa, PCG tolerance, max PCG iter
+
+    1     <-- Number of exception rules
+    2 4 0.     <-- Exception rule #1: smoothing across region 2, 4 boundary 
+                    this should be a real number; 0. means no smoothing
+                    repeat these lines for each exception
+    1 11   <-- Start index array specification
+            
+    9 9 9 9 9 9 9 9 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
+    9 9 9 9 9 9 9 9 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
+    9 9 9 9 9 9 9 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
+    9 9 9 9 9 9 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
+    9 9 9 9 9 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
+    9 9 9 9 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
+    9 9 9 4 4 4 4 4 1 1 1 1 1 1 4 4 4 4 4 4 4 4 4 4 4 4 4 4
+    9 9 9 4 4 4 4 4 1 1 1 1 1 1 4 4 4 4 4 4 4 4 4 4 4 4 4 4
+    9 9 9 4 4 4 4 4 1 1 1 1 1 1 4 4 4 4 4 4 4 4 4 4 4 4 4 4
+    9 9 9 4 4 4 4 4 1 1 1 1 1 1 4 4 4 4 4 4 4 4 4 4 4 4 4 4
+    9 9 9 9 4 4 4 4 1 1 1 1 1 1 4 4 4 4 4 4 4 4 4 4 4 4 4 4
+    9 9 9 9 9 4 4 4 1 1 1 1 1 1 4 4 4 4 4 4 4 4 4 4 4 4 4 4
+    9 9 9 9 9 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4
+    9 9 9 9 9 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4
+    9 9 9 9 9 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4
+    9 9 9 9 9 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4
+    9 9 9 9 9 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4
+    9 9 9 9 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4
+    9 9 9 9 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4
+    9 9 9 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4
+    9 9 9 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4
+
+The Sx, Sy, Sz values are placeholders for future extensions and are not used in 
+the current Bi-Helmholtz implementation. Exception rules use the same 3-value 
+format as CovType=1; the third value (smoothing) is read but not used for
+CovType=2 (tears are determined by rule presence).
+
+**Cross-compatibility**: The code is tolerant when file and CovType don't match.
+If a CovType=2 file is read with CovType=1 selected (or vice versa), a warning
+is printed and the mask is read from the file while defaults are used for the
+other parameters.
+
+
 For 2D MT, Weerachai Siripuvaraporn's model covariance is used. No configuration
 file is currently allowed.
 

--- a/f90/2D_MT/Sub_MPI.f90
+++ b/f90/2D_MT/Sub_MPI.f90
@@ -100,7 +100,7 @@ end subroutine pack_userdef_control
  subroutine unpack_userdef_control(ctrl)
     implicit none
 
-     	type(userdef_control), intent(in)   :: ctrl
+     	type(userdef_control), intent(inout)   :: ctrl
         integer index
 
        index=1

--- a/f90/3D_MT/FWD_SP2/gpu_lock.h
+++ b/f90/3D_MT/FWD_SP2/gpu_lock.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <fcntl.h>
 #include <new>
+#include <sched.h>
 #include <sys/mman.h>
 #include <unistd.h>
 
@@ -24,7 +25,7 @@ static constexpr int LOCK_MAX_DEVICES = 64;
 // All other members are std::atomic<int>, constructed by placement-new once,
 // then used via normal C++ atomic operations.
 struct alignas(64) GpuLock {
-    int cnstr;      // 0 = not constructed, 1 = atomics live
+    int cnstr;      // 0 = not constructed, 1 = atomics live, 2 = init in progress
     std::atomic<int> occupied[LOCK_MAX_DEVICES];
 };
 
@@ -51,23 +52,46 @@ static inline int init_gpu_lock()
     close(fd);
     if (g_lock == MAP_FAILED) { g_lock = nullptr; return 1; }
 
-    // Coordinate exactly-once construction of std::atomic members.   
-    // cnstr uses __atomic_* built-ins: safe on raw storage       
-    // the winner does placement-new on every std::atomic<int>     
-    // the other (losers) spin-wait with ACQUIRE on "cnstr" until it's 1, 
-    // then proceed to use the atomics.
+    // Exactly-once (re-)initialization of std::atomic members.
+    // cnstr: 0=uninit/stale, 2=init-in-progress, 1=ready.
+    //
+    // Both 0 (fresh shm) and 1 (stale from a previous crash — some
+    // occupied[] may still be DEVICE_IN_USE) trigger CAS to 2. The
+    // winner does placement-new + reset, clearing all stale lock bits.
+    // Losers yield while cnstr == 2. If the initializer crashes, cnstr
+    // may revert to 0; the next iteration retries.
+    //
+    // A cleanly-terminated previous job always calls shm_unlink, so
+    // finding an existing segment implies the last job crashed — it is
+    // safe to reconstruct atomics unconditionally.
 
-    if (__atomic_exchange_n(&g_lock->cnstr, 1, __ATOMIC_ACQ_REL) != 0) {
-        // Another process won the race — spin-wait until construction finishes.
-        while (!__atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE))
-            ;
-    } else {
-        // We are the winner — construct all std::atomic members.
-        for (int i = 0; i < LOCK_MAX_DEVICES; i++)
-            new (&g_lock->occupied[i]) std::atomic<int>(DEVICE_FREE);
+    while (1) {
+        int old = __atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE);
 
-        // cnstr is already 1 from the exchange above (ACQ_REL ensures
-        // the constructed atomics are visible to other processes).
+        if (old == 2) {
+	        // Another rank is initializing; yield until it finishes.
+            do {
+		        // yield, instead of busy-waiting...
+                sched_yield();
+                old = __atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE);
+            } while (old == 2);
+            continue;
+        }
+
+        // old is 0 (fresh) or 1 (stale ready with possibly stuck locks).
+        // Try CAS {0, 1} → 2 to become the (re-)initializer.
+        if (__atomic_compare_exchange_n(&g_lock->cnstr, &old, 2,
+                                         false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+        {
+            for (int i = 0; i < LOCK_MAX_DEVICES; i++)
+                new (&g_lock->occupied[i]) std::atomic<int>(DEVICE_FREE);
+            for (int i = 0; i < LOCK_MAX_DEVICES; i++)
+                g_lock->occupied[i].store(DEVICE_FREE, std::memory_order_release);
+            __atomic_store_n(&g_lock->cnstr, 1, __ATOMIC_RELEASE);
+            break;
+        }
+        // else
+        // CAS failed — another rank changed cnstr; loop and re-evaluates.
     }
 
     g_lock_inited = true;
@@ -87,8 +111,11 @@ extern "C" void cf_releaseDev(int dev_idx)
 
 extern "C" void cf_cleanupLock()
 {
-    if (g_lock != nullptr && g_lock != MAP_FAILED)
+    if (g_lock != nullptr && g_lock != MAP_FAILED) {
+        // also reset cnstr so the next init_gpu_lock starts cleanly
+        __atomic_store_n(&g_lock->cnstr, 0, __ATOMIC_RELEASE);
         munmap(g_lock, sizeof(GpuLock));
+    }
     shm_unlink("/ModEM_gpu_lock");
     g_lock = nullptr;
     g_lock_inited = false;

--- a/f90/3D_MT/Main.f90
+++ b/f90/3D_MT/Main.f90
@@ -213,6 +213,12 @@ Contains
         call create_rhsVectorMTX(allData%nTx,bAll)
     end if
 
+    !--------------------------------------------------------------------------
+    ! Set covariance backend.  cUserDef%CovType is already finalized by
+    ! UserCtrl::finalize_covType (invoked from Mod3DMT before initGlobalData),
+    ! absorbing any overrides from namelist, -C CLI arg, or inv-ctrl 9th line.
+    call set_CovType(cUserDef%CovType)
+
 	!--------------------------------------------------------------------------
 	!  Initialize additional data as necessary
 	select case (cUserDef%job)

--- a/f90/3D_MT/Sub_MPI.f90
+++ b/f90/3D_MT/Sub_MPI.f90
@@ -180,7 +180,7 @@ end subroutine unpack_userdef_control
 !********************************************************************
 subroutine check_userdef_control_MPI (which_proc,ctrl)
 
-    type(userdef_control), intent(in)   :: ctrl
+     	type(userdef_control), intent(inout)   :: ctrl
     character(20), intent(in)           :: which_proc
 
     write(6,*)trim(which_proc),' : ctrl%wFile_Sens ',trim(ctrl%wFile_Sens)

--- a/f90/3D_MT/modelParam/ModelSpace.f90
+++ b/f90/3D_MT/modelParam/ModelSpace.f90
@@ -29,7 +29,9 @@ module ModelSpace
   use sg_scalar
   use sg_vector
   use sg_sparse_vector
+#ifdef SP_FORM
   use spOpTools
+#endif
 #ifdef MPI
   use Declaration_MPI
 #endif
@@ -166,7 +168,9 @@ end interface
 ! definitions for CmSqrt: must be consistent with the include file below
 
 #include "modelCov/RecursiveAR.hd"
+#ifdef SP_FORM
 #include "modelCov/BiHelmholtz.hd"
+#endif
 
   ! CovType: 1 = AR (default), 2 = Bi-Helmholtz
   integer, save :: CovType = 1
@@ -181,9 +185,22 @@ Contains
 
 !  Backend implementations
 #include "modelCov/RecursiveAR.inc"
+#ifdef SP_FORM
 #include "modelCov/BiHelmholtz.inc"
+#endif
 
-!  Dispatcher functions: route to CovType=1 (AR) or CovType=2 (Bi-Helmholtz) backends
+!  dummy functions for covtype (always available, not dependent on spOpTools)
+subroutine set_CovType(covTypeIn)
+  integer, intent(in) :: covTypeIn
+  CovType = covTypeIn
+end subroutine set_CovType
+
+function get_CovType() result(covTypeOut)
+  integer :: covTypeOut
+  covTypeOut = CovType
+end function get_CovType
+
+!  real functions: route to CovType=1 (AR) or CovType=2 (Bi-Helmholtz) backends
 
   function multBy_Cm(mhat) result(dm)
     type (modelParam_t), intent(in) :: mhat
@@ -191,8 +208,10 @@ Contains
     select case (CovType)
     case (1)
        dm = multBy_Cm_AR(mhat)
+#ifdef SP_FORM
     case (2)
        dm = multBy_Cm_BiHelm(mhat)
+#endif
     case default
        call errStop('Unknown CovType in multBy_Cm')
     end select
@@ -204,8 +223,10 @@ Contains
     select case (CovType)
     case (1)
        dm = multBy_CmSqrt_AR(mhat)
+#ifdef SP_FORM
     case (2)
        dm = multBy_CmSqrt_BiHelm(mhat)
+#endif
     case default
        call errStop('Unknown CovType in multBy_CmSqrt')
     end select
@@ -217,8 +238,10 @@ Contains
     select case (CovType)
     case (1)
        mhat = multBy_CmSqrtInv_AR(dm)
+#ifdef SP_FORM
     case (2)
        mhat = multBy_CmSqrtInv_BiHelm(dm)
+#endif
     case default
        call errStop('Unknown CovType in multBy_CmSqrtInv')
     end select
@@ -230,8 +253,10 @@ Contains
     select case (CovType)
     case (1)
        call create_CmSqrt_AR(m, cfile)
+#ifdef SP_FORM
     case (2)
        call create_CmSqrt_BiHelm(m, cfile)
+#endif
     case default
        call errStop('Unknown CovType in create_CmSqrt')
     end select
@@ -241,8 +266,10 @@ Contains
     select case (CovType)
     case (1)
        call deall_CmSqrt_AR()
+#ifdef SP_FORM
     case (2)
        call deall_CmSqrt_BiHelm()
+#endif
     case default
        call errStop('Unknown CovType in deall_CmSqrt')
     end select

--- a/f90/3D_MT/modelParam/ModelSpace.f90
+++ b/f90/3D_MT/modelParam/ModelSpace.f90
@@ -29,6 +29,7 @@ module ModelSpace
   use sg_scalar
   use sg_vector
   use sg_sparse_vector
+  use spOpTools
 #ifdef MPI
   use Declaration_MPI
 #endif
@@ -165,7 +166,11 @@ end interface
 ! definitions for CmSqrt: must be consistent with the include file below
 
 #include "modelCov/RecursiveAR.hd"
-!#include "modelCov/Diffusion.hd"
+#include "modelCov/BiHelmholtz.hd"
+
+  ! CovType: 1 = AR (default), 2 = Bi-Helmholtz
+  integer, save :: CovType = 1
+
 Contains
 
 ! *****************************************************************************
@@ -174,9 +179,74 @@ Contains
 !  model parameter structure
 #include "ModelMap.inc"
 
-!  The included file must contain subroutines create_CmSqrt, deall_CmSqrt, multBy...
+!  Backend implementations
 #include "modelCov/RecursiveAR.inc"
-!#include "modelCov/Diffusion.inc"
+#include "modelCov/BiHelmholtz.inc"
+
+!  Dispatcher functions: route to CovType=1 (AR) or CovType=2 (Bi-Helmholtz) backends
+
+  function multBy_Cm(mhat) result(dm)
+    type (modelParam_t), intent(in) :: mhat
+    type (modelParam_t)             :: dm
+    select case (CovType)
+    case (1)
+       dm = multBy_Cm_AR(mhat)
+    case (2)
+       dm = multBy_Cm_BiHelm(mhat)
+    case default
+       call errStop('Unknown CovType in multBy_Cm')
+    end select
+  end function multBy_Cm
+
+  function multBy_CmSqrt(mhat) result(dm)
+    type (modelParam_t), intent(in) :: mhat
+    type (modelParam_t)             :: dm
+    select case (CovType)
+    case (1)
+       dm = multBy_CmSqrt_AR(mhat)
+    case (2)
+       dm = multBy_CmSqrt_BiHelm(mhat)
+    case default
+       call errStop('Unknown CovType in multBy_CmSqrt')
+    end select
+  end function multBy_CmSqrt
+
+  function multBy_CmSqrtInv(dm) result(mhat)
+    type (modelParam_t), intent(in) :: dm
+    type (modelParam_t)             :: mhat
+    select case (CovType)
+    case (1)
+       mhat = multBy_CmSqrtInv_AR(dm)
+    case (2)
+       mhat = multBy_CmSqrtInv_BiHelm(dm)
+    case default
+       call errStop('Unknown CovType in multBy_CmSqrtInv')
+    end select
+  end function multBy_CmSqrtInv
+
+  subroutine create_CmSqrt(m, cfile)
+    type (modelParam_t), intent(in) :: m
+    character(*), intent(in), optional :: cfile
+    select case (CovType)
+    case (1)
+       call create_CmSqrt_AR(m, cfile)
+    case (2)
+       call create_CmSqrt_BiHelm(m, cfile)
+    case default
+       call errStop('Unknown CovType in create_CmSqrt')
+    end select
+  end subroutine create_CmSqrt
+
+  subroutine deall_CmSqrt()
+    select case (CovType)
+    case (1)
+       call deall_CmSqrt_AR()
+    case (2)
+       call deall_CmSqrt_BiHelm()
+    case default
+       call errStop('Unknown CovType in deall_CmSqrt')
+    end select
+  end subroutine deall_CmSqrt
 
 !  MPI model parameter, if needed
 #ifdef MPI

--- a/f90/3D_MT/modelParam/ModelSpace.f90
+++ b/f90/3D_MT/modelParam/ModelSpace.f90
@@ -172,7 +172,7 @@ end interface
 #include "modelCov/BiHelmholtz.hd"
 #endif
 
-  ! CovType: 1 = AR (default), 2 = Bi-Helmholtz
+  ! CovType: 1 = AR (default), 2 = H2 (Bi-Helmholtz)
   integer, save :: CovType = 1
 
 Contains
@@ -200,7 +200,7 @@ function get_CovType() result(covTypeOut)
   covTypeOut = CovType
 end function get_CovType
 
-!  real functions: route to CovType=1 (AR) or CovType=2 (Bi-Helmholtz) backends
+!  real functions: route to CovType=1 (AR) or CovType=2 (H2 / Bi-Helmholtz) backends
 
   function multBy_Cm(mhat) result(dm)
     type (modelParam_t), intent(in) :: mhat
@@ -766,7 +766,10 @@ end function get_CovType
 
     ! try 4 ints (new format: Nx Ny NzEarth FileType)
     read(line, *, iostat=istat) Nx, Ny, NzEarth, fileType
-    if (istat == 0 .and. fileType >= 1 .and. fileType <= 2) return
+    if (istat == 0) then
+       if (fileType >= 1 .and. fileType <= 2) return
+       call errStop('Invalid CovType in covariance file (must be 1 or 2)')
+    end if
 
     ! try 3 ints (legacy: Nx Ny NzEarth, default to CovType=1)
     read(line, *, iostat=istat) Nx, Ny, NzEarth

--- a/f90/3D_MT/modelParam/ModelSpace.f90
+++ b/f90/3D_MT/modelParam/ModelSpace.f90
@@ -740,4 +740,43 @@ end function get_CovType
 
   end subroutine getValueUpdated_modelParam
 
+!**********************************************************************
+!  Detects the filetype (CovType) from line 17 of a covariance file.
+!  Reads the first non-blank line after the 16-line header and parses:
+!    - 4 ints (Nx Ny NzEarth FileType): new format, FileType must be 1 or 2
+!    - 3 ints (Nx Ny NzEarth):          legacy format, defaults to FileType=1
+!    - anything else:                   error
+!
+!  Both read_CmSqrt_AR and read_CmSqrt_BiHelm call this routine.
+
+  subroutine detect_cov_filetype(fid, Nx, Ny, NzEarth, fileType)
+
+    integer, intent(in)                          :: fid
+    integer, intent(out)                         :: Nx, Ny, NzEarth, fileType
+    character(len=256)                           :: line
+    integer                                      :: istat
+
+    ! skip blank lines after header
+    do
+       read(fid, '(A)', iostat=istat) line
+       if (istat /= 0) call errStop('Error reading covariance file after header')
+       line = adjustl(line)
+       if (line /= '') exit
+    end do
+
+    ! try 4 ints (new format: Nx Ny NzEarth FileType)
+    read(line, *, iostat=istat) Nx, Ny, NzEarth, fileType
+    if (istat == 0 .and. fileType >= 1 .and. fileType <= 2) return
+
+    ! try 3 ints (legacy: Nx Ny NzEarth, default to CovType=1)
+    read(line, *, iostat=istat) Nx, Ny, NzEarth
+    if (istat == 0) then
+       fileType = 1
+       return
+    end if
+
+    call errStop('Invalid grid dimensions / CovType in covariance file')
+
+  end subroutine detect_cov_filetype
+
 end module ModelSpace

--- a/f90/3D_MT/modelParam/modelCov/BiHelmholtz.hd
+++ b/f90/3D_MT/modelParam/modelCov/BiHelmholtz.hd
@@ -1,0 +1,41 @@
+!----------------------------------------------------------------------!
+! 3D_MT Bi-Helmholtz covariance (CovType=2): definitions.              !
+!                                                                      !
+!   K = C_m^{1/2} = A^{-1}  where A = kappa^2 I - Delta              !
+!   C_m = A^{-2}                                                      !
+!   K^{-1} = A                                                       !
+!----------------------------------------------------------------------!
+
+  type :: modelCovBiHelm_t
+
+    private
+
+    ! grid dimensions (earth cells only)
+    integer                                           :: Nx, Ny, NzEarth
+
+    ! BiHelmholtz parameter kappa (> 0)
+    real (kind=prec)                          :: kappa
+
+    ! sparse operator A = kappa^2 I - Delta (CSR format)
+    type (spMatCSR_Real)                             :: A
+
+    ! an integer array that defines regions for smoothing and scaling purposes
+    type (iscalar)                                    :: mask
+
+    ! PCG solver controls
+    real (kind=prec)                          :: pcg_tol
+    integer                                           :: pcg_maxIt
+
+    ! exception rules: turn off smoothing across boundaries between
+    ! specific mask-code pairs (order independent)
+    logical                                           :: tearMatrix(0:9, 0:9)
+    integer                                           :: nrules
+    integer, pointer, dimension(:, :)         :: tearPairs
+
+    ! true when all arrays are allocated, initialized and ready to use
+    logical                                           :: allocated
+
+  end type
+
+  ! CmSqrtBiHelm (an instance of modelCovBiHelm_t), saved and private
+  type (modelCovBiHelm_t), private, save               :: CmSqrtBiHelm

--- a/f90/3D_MT/modelParam/modelCov/BiHelmholtz.hd
+++ b/f90/3D_MT/modelParam/modelCov/BiHelmholtz.hd
@@ -1,5 +1,5 @@
 !----------------------------------------------------------------------!
-! 3D_MT Bi-Helmholtz covariance (CovType=2): definitions.              !
+! 3D_MT H2 (Bi-Helmholtz) covariance (CovType=2): definitions.         !
 !                                                                      !
 !   K = C_m^{1/2} = A^{-1}  where A = kappa^2 I - Delta              !
 !   C_m = A^{-2}                                                      !
@@ -7,7 +7,7 @@
 !                                                                      !
 !   Unified cov file format (line 17):                                !
 !     Nx Ny NzEarth FileType   (3 ints = legacy AR, 4 ints = new)    !
-!     Sx, Sy, Sz (placeholders, not used by BiHelmholtz)              !
+!     Sx, Sy, Sz (placeholders, not used by H2)                       !
 !     N kappa pcg_tol pcg_maxIt (parameter array)                     !
 !     nrules, mask1 mask2 smoothing (exception rules, 3 per rule)     !
 !     mask blocks (read_iscalar format)                                !
@@ -20,7 +20,7 @@
     ! grid dimensions (earth cells only)
     integer                                           :: Nx, Ny, NzEarth
 
-    ! BiHelmholtz parameter kappa (> 0)
+    ! H2 parameter kappa (> 0)
     real (kind=prec)                          :: kappa
 
     ! sparse operator A = kappa^2 I - Delta (CSR format)
@@ -51,6 +51,6 @@
   public    :: create_CmSqrt_BiHelm, deall_CmSqrt_BiHelm, multBy_CmSqrt_BiHelm, &
                multBy_Cm_BiHelm, multBy_CmSqrtInv_BiHelm
 
-  ! private procedures for the BiHelmholtz covariance
+  ! private procedures for the H2 (Bi-Helmholtz) covariance
   private   :: apply_A_BiHelm, apply_freeze_semantics_BiHelm, solve_A_BiHelm, &
                assemble_A_BiHelm, read_CmSqrt_BiHelm

--- a/f90/3D_MT/modelParam/modelCov/BiHelmholtz.hd
+++ b/f90/3D_MT/modelParam/modelCov/BiHelmholtz.hd
@@ -4,6 +4,13 @@
 !   K = C_m^{1/2} = A^{-1}  where A = kappa^2 I - Delta              !
 !   C_m = A^{-2}                                                      !
 !   K^{-1} = A                                                       !
+!                                                                      !
+!   Unified cov file format (line 17):                                !
+!     Nx Ny NzEarth FileType   (3 ints = legacy AR, 4 ints = new)    !
+!     Sx, Sy, Sz (placeholders, not used by BiHelmholtz)              !
+!     N kappa pcg_tol pcg_maxIt (parameter array)                     !
+!     nrules, mask1 mask2 smoothing (exception rules, 3 per rule)     !
+!     mask blocks (read_iscalar format)                                !
 !----------------------------------------------------------------------!
 
   type :: modelCovBiHelm_t
@@ -39,3 +46,11 @@
 
   ! CmSqrtBiHelm (an instance of modelCovBiHelm_t), saved and private
   type (modelCovBiHelm_t), private, save               :: CmSqrtBiHelm
+
+  ! public procedures to create, deallocate and multiply by CmSqrtBiHelm
+  public    :: create_CmSqrt_BiHelm, deall_CmSqrt_BiHelm, multBy_CmSqrt_BiHelm, &
+               multBy_Cm_BiHelm, multBy_CmSqrtInv_BiHelm
+
+  ! private procedures for the BiHelmholtz covariance
+  private   :: apply_A_BiHelm, apply_freeze_semantics_BiHelm, solve_A_BiHelm, &
+               assemble_A_BiHelm, read_CmSqrt_BiHelm

--- a/f90/3D_MT/modelParam/modelCov/BiHelmholtz.inc
+++ b/f90/3D_MT/modelParam/modelCov/BiHelmholtz.inc
@@ -1,14 +1,14 @@
 !----------------------------------------------------------------------!
-! 3D_MT Bi-Helmholtz covariance (CovType=2): procedures.               !
+! 3D_MT H2 (Bi-Helmholtz) covariance (CovType=2): procedures.          !
 !                                                                      !
-!   BiHelmholtz precision operator:  A = kappa^2 I - Delta                   !
+!   H2 precision operator:  A = kappa^2 I - Delta                      !
 !   Matérn order alpha=2:     C_m = A^{-2},  K = A^{-1}               !
 !----------------------------------------------------------------------!
 
 ! *******************************************************************
   subroutine read_CmSqrt_BiHelm(cfile)
 
-    ! Reads the BiHelmholtz covariance configuration from file.
+    ! Reads the H2 (Bi-Helmholtz) covariance configuration from file.
     ! Supports the unified cov file format:
     !   Line 17: Nx Ny NzEarth FileType  (or legacy Nx Ny NzEarth)
     !   Sx, Sy, Sz (placeholders)
@@ -16,7 +16,7 @@
     !   nrules, exception rules (3 values per rule)
     !   mask blocks
     ! When fileType=1 (AR format) is detected with CovType=2 selected,
-    ! reads the mask and uses BiHelmholtz defaults.
+    ! reads the mask and uses H2 defaults.
 
     character(*), intent(in)                         :: cfile
     integer                                          :: fid, j, fileType
@@ -44,7 +44,7 @@
     CmSqrtBiHelm%NzEarth = NzEarth
 
     if (fileType == 2) then
-       ! normal BiHelmholtz read: skip Sx, Sy, Sz (placeholders)
+        ! normal H2 read: skip Sx, Sy, Sz (placeholders)
        allocate(tempSx(NzEarth), tempSy(NzEarth), STAT=istat)
        read(fid,*) tempSx
        read(fid,*) tempSy
@@ -56,21 +56,21 @@
        read(fid,*,iostat=istat) tempN, CmSqrtBiHelm%kappa, &
             CmSqrtBiHelm%pcg_tol, CmSqrtBiHelm%pcg_maxIt
        if (istat /= 0) then
-          call errStop('Error reading BiHelmholtz parameters in '//cfile)
+           call errStop('Error reading H2 (Bi-Helmholtz) parameters in '//cfile)
        end if
        if (CmSqrtBiHelm%kappa <= 0.0_prec) then
-          call errStop('BiHelmholtz kappa must be positive in covariance file '//cfile)
+           call errStop('H2 kappa must be positive in covariance file '//cfile)
        end if
        if (CmSqrtBiHelm%pcg_tol <= 0.0_prec) then
-          call errStop('BiHelmholtz pcg_tol must be positive in covariance file '//cfile)
+           call errStop('H2 pcg_tol must be positive in covariance file '//cfile)
        end if
        if (CmSqrtBiHelm%pcg_maxIt <= 0) then
-          call errStop('BiHelmholtz pcg_maxIt must be positive in covariance file '//cfile)
+           call errStop('H2 pcg_maxIt must be positive in covariance file '//cfile)
        end if
     else
-       ! fileType=1 with CovType=2 selected: read mask, use BiHelmholtz defaults
-       write(0,*) 'Warning: AR cov file read with CovType=2.'
-       write(0,*) '  Using BiHelmholtz defaults for kappa, pcg parameters.'
+        ! fileType=1 with CovType=2 selected: read mask, use H2 defaults
+        write(0,*) 'Warning: AR cov file read with CovType=2.'
+        write(0,*) '  Using H2 defaults for kappa, pcg parameters.'
        allocate(tempSx(NzEarth), tempSy(NzEarth), STAT=istat)
        read(fid,*) tempSx
        read(fid,*) tempSy
@@ -114,7 +114,7 @@
 ! *******************************************************************
   subroutine create_CmSqrt_BiHelm(m, cfile)
 
-    ! Initializes the BiHelmholtz covariance. If cfile is provided, reads
+    ! Initializes the H2 (Bi-Helmholtz) covariance. If cfile is provided, reads
     ! configuration from file; otherwise uses defaults.
 
     type (modelParam_t), intent(in)     :: m
@@ -209,8 +209,8 @@
     integer                         :: Nx, Ny, NzEarth, nCells
     integer                         :: i, j, k, idx, idx_nb
     integer                         :: nnz, nz, istat, p
-   real (kind=prec)                :: kappa2
-   real (kind=prec)                :: diagA
+    real (kind=prec)               :: kappa2
+    real (kind=prec)               :: diagA
     integer, allocatable            :: rowT(:)
 
     Nx = m%Nx
@@ -464,7 +464,7 @@
     integer                       :: i, j, k, idx, it, istat
     real (kind=prec), allocatable :: r(:), p(:), z(:), q(:), x(:), b(:)
     real (kind=prec), allocatable :: diag(:)
-   real (kind=prec)              :: alpha, beta, rsold, rsnew, bnrm, denom
+    real (kind=prec)              :: alpha, beta, rsold, rsnew, bnrm, denom
     logical                       :: earlyExit
 
     Nx = size(rhs, 1)

--- a/f90/3D_MT/modelParam/modelCov/BiHelmholtz.inc
+++ b/f90/3D_MT/modelParam/modelCov/BiHelmholtz.inc
@@ -6,18 +6,6 @@
 !----------------------------------------------------------------------!
 
 ! *******************************************************************
-  subroutine set_CovType(covTypeIn)
-    integer, intent(in) :: covTypeIn
-    CovType = covTypeIn
-  end subroutine set_CovType
-
-! *******************************************************************
-  function get_CovType() result(covTypeOut)
-    integer :: covTypeOut
-    covTypeOut = CovType
-  end function get_CovType
-
-! *******************************************************************
   subroutine read_CmSqrt_BiHelm(cfile)
 
     ! Reads the BiHelmholtz covariance configuration from file.

--- a/f90/3D_MT/modelParam/modelCov/BiHelmholtz.inc
+++ b/f90/3D_MT/modelParam/modelCov/BiHelmholtz.inc
@@ -9,11 +9,22 @@
   subroutine read_CmSqrt_BiHelm(cfile)
 
     ! Reads the BiHelmholtz covariance configuration from file.
+    ! Supports the unified cov file format:
+    !   Line 17: Nx Ny NzEarth FileType  (or legacy Nx Ny NzEarth)
+    !   Sx, Sy, Sz (placeholders)
+    !   Parameter array (CovType-specific)
+    !   nrules, exception rules (3 values per rule)
+    !   mask blocks
+    ! When fileType=1 (AR format) is detected with CovType=2 selected,
+    ! reads the mask and uses BiHelmholtz defaults.
 
     character(*), intent(in)                         :: cfile
-    integer                                           :: fid, j, covTypeRead
-    integer                                           :: Nx, Ny, NzEarth
-    integer                                           :: istat
+    integer                                          :: fid, j, fileType
+    integer                                          :: Nx, Ny, NzEarth, nrules
+    integer                                          :: istat
+    real (kind=prec), allocatable                    :: tempSx(:), tempSy(:)
+    real (kind=prec)                                 :: tempSz
+    integer                                          :: tempN
 
     fid = 30
     open(unit=fid,file=cfile,form='formatted',status='old')
@@ -23,14 +34,8 @@
        read(fid,*)
     end do
 
-    ! read CovType (must be 2)
-    read(fid,*) covTypeRead
-    if (covTypeRead /= 2) then
-       call errStop('BiHelmholtz covariance file must have CovType=2 on line 17')
-    end if
-
-    ! read grid dimensions
-    read(fid,*) Nx, Ny, NzEarth
+    ! detect filetype and read grid dimensions from line 17
+    call detect_cov_filetype(fid, Nx, Ny, NzEarth, fileType)
     if (Nx <= 0 .or. Ny <= 0 .or. NzEarth <= 0) then
        call errStop('Invalid grid dimensions in covariance file '//cfile)
     end if
@@ -38,34 +43,58 @@
     CmSqrtBiHelm%Ny = Ny
     CmSqrtBiHelm%NzEarth = NzEarth
 
-    ! read kappa (dimensionless, correlation length ~ 1/kappa cells)
-    read(fid,*) CmSqrtBiHelm%kappa
-    if (CmSqrtBiHelm%kappa <= 0.0_prec) then
-       call errStop('BiHelmholtz kappa must be positive in covariance file '//cfile)
+    if (fileType == 2) then
+       ! normal BiHelmholtz read: skip Sx, Sy, Sz (placeholders)
+       allocate(tempSx(NzEarth), tempSy(NzEarth), STAT=istat)
+       read(fid,*) tempSx
+       read(fid,*) tempSy
+       read(fid,*) tempSz
+       deallocate(tempSx, tempSy, STAT=istat)
+       ! read parameter array: N kappa pcg_tol pcg_maxIt
+       ! All 4 values on one line; read in a single statement so that
+       ! list-directed I/O does not advance past the record boundary.
+       read(fid,*,iostat=istat) tempN, CmSqrtBiHelm%kappa, &
+            CmSqrtBiHelm%pcg_tol, CmSqrtBiHelm%pcg_maxIt
+       if (istat /= 0) then
+          call errStop('Error reading BiHelmholtz parameters in '//cfile)
+       end if
+       if (CmSqrtBiHelm%kappa <= 0.0_prec) then
+          call errStop('BiHelmholtz kappa must be positive in covariance file '//cfile)
+       end if
+       if (CmSqrtBiHelm%pcg_tol <= 0.0_prec) then
+          call errStop('BiHelmholtz pcg_tol must be positive in covariance file '//cfile)
+       end if
+       if (CmSqrtBiHelm%pcg_maxIt <= 0) then
+          call errStop('BiHelmholtz pcg_maxIt must be positive in covariance file '//cfile)
+       end if
+    else
+       ! fileType=1 with CovType=2 selected: read mask, use BiHelmholtz defaults
+       write(0,*) 'Warning: AR cov file read with CovType=2.'
+       write(0,*) '  Using BiHelmholtz defaults for kappa, pcg parameters.'
+       allocate(tempSx(NzEarth), tempSy(NzEarth), STAT=istat)
+       read(fid,*) tempSx
+       read(fid,*) tempSy
+       read(fid,*) tempSz
+       deallocate(tempSx, tempSy, STAT=istat)
+       ! skip N (AR smoothing passes)
+       read(fid,*) tempN
+       CmSqrtBiHelm%kappa = 0.5_prec
+       CmSqrtBiHelm%pcg_tol = 1.0e-7_prec
+       CmSqrtBiHelm%pcg_maxIt = 250
     end if
 
-    ! read solver controls
-    read(fid,*,iostat=istat) CmSqrtBiHelm%pcg_tol
-    if (istat /= 0 .or. CmSqrtBiHelm%pcg_tol <= 0.0_prec) then
-       call errStop('BiHelmholtz pcg_tol must be positive in covariance file '//cfile)
+    ! read exception rules (3 values per rule; third value unused for CovType=2)
+    read(fid,*,iostat=istat) nrules
+    if (istat /= 0 .or. nrules < 0) then
+       call errStop('Invalid nrules in covariance file '//cfile)
     end if
-    read(fid,*,iostat=istat) CmSqrtBiHelm%pcg_maxIt
-    if (istat /= 0 .or. CmSqrtBiHelm%pcg_maxIt <= 0) then
-       call errStop('BiHelmholtz pcg_maxIt must be positive in covariance file '//cfile)
-    end if
-
-    ! read exception rules (order-independent mask-code pairs: smoothing
-    ! is turned off across faces between cells with these mask codes)
-    read(fid,*,iostat=istat) CmSqrtBiHelm%nrules
-    if (istat /= 0 .or. CmSqrtBiHelm%nrules < 0) then
-       call errStop('BiHelmholtz cov file must have nrules (>= 0) after pcg_maxIt')
-    end if
+    CmSqrtBiHelm%nrules = nrules
     CmSqrtBiHelm%tearMatrix = .false.
-    if (CmSqrtBiHelm%nrules > 0) then
-       allocate(CmSqrtBiHelm%tearPairs(2, CmSqrtBiHelm%nrules), stat=istat)
+    if (nrules > 0) then
+       allocate(CmSqrtBiHelm%tearPairs(2, nrules), stat=istat)
        if (istat /= 0) call errStop('Memory allocation failed for tearPairs')
-       do j = 1, CmSqrtBiHelm%nrules
-          read(fid,*) CmSqrtBiHelm%tearPairs(1,j), CmSqrtBiHelm%tearPairs(2,j)
+       do j = 1, nrules
+          read(fid,*) CmSqrtBiHelm%tearPairs(1,j), CmSqrtBiHelm%tearPairs(2,j), tempSz
           if (CmSqrtBiHelm%tearPairs(1,j) < 0 .or. CmSqrtBiHelm%tearPairs(1,j) > 9 .or. &
               CmSqrtBiHelm%tearPairs(2,j) < 0 .or. CmSqrtBiHelm%tearPairs(2,j) > 9) then
              call errStop('Invalid mask code in tear rule (must be 0-9)')
@@ -177,8 +206,8 @@
     ! Counting pass first, then fill pass.
 
     type (modelParam_t), intent(in) :: m
-    integer                         :: Nx, Ny, NzEarth, nCells, nzAir
-    integer                         :: i, j, k, kz, idx, idx_nb
+    integer                         :: Nx, Ny, NzEarth, nCells
+    integer                         :: i, j, k, idx, idx_nb
     integer                         :: nnz, nz, istat, p
    real (kind=prec)                :: kappa2
    real (kind=prec)                :: diagA
@@ -187,7 +216,6 @@
     Nx = m%Nx
     Ny = m%Ny
     NzEarth = m%NzEarth
-    nzAir = m%grid%nzAir
     nCells = Nx * Ny * NzEarth
     kappa2 = CmSqrtBiHelm%kappa**2
 
@@ -248,7 +276,6 @@
 
     ! Pass 2: fill columns and values
     do k = 1, NzEarth
-       kz = k + nzAir
        do j = 1, Ny
           do i = 1, Nx
              idx = (k-1)*Nx*Ny + (j-1)*Nx + i

--- a/f90/3D_MT/modelParam/modelCov/BiHelmholtz.inc
+++ b/f90/3D_MT/modelParam/modelCov/BiHelmholtz.inc
@@ -1,0 +1,706 @@
+!----------------------------------------------------------------------!
+! 3D_MT Bi-Helmholtz covariance (CovType=2): procedures.               !
+!                                                                      !
+!   BiHelmholtz precision operator:  A = kappa^2 I - Delta                   !
+!   Matérn order alpha=2:     C_m = A^{-2},  K = A^{-1}               !
+!----------------------------------------------------------------------!
+
+! *******************************************************************
+  subroutine set_CovType(covTypeIn)
+    integer, intent(in) :: covTypeIn
+    CovType = covTypeIn
+  end subroutine set_CovType
+
+! *******************************************************************
+  function get_CovType() result(covTypeOut)
+    integer :: covTypeOut
+    covTypeOut = CovType
+  end function get_CovType
+
+! *******************************************************************
+  subroutine read_CmSqrt_BiHelm(cfile)
+
+    ! Reads the BiHelmholtz covariance configuration from file.
+
+    character(*), intent(in)                         :: cfile
+    integer                                           :: fid, j, covTypeRead
+    integer                                           :: Nx, Ny, NzEarth
+    integer                                           :: istat
+
+    fid = 30
+    open(unit=fid,file=cfile,form='formatted',status='old')
+
+    ! skip 16-line header
+    do j = 1, 16
+       read(fid,*)
+    end do
+
+    ! read CovType (must be 2)
+    read(fid,*) covTypeRead
+    if (covTypeRead /= 2) then
+       call errStop('BiHelmholtz covariance file must have CovType=2 on line 17')
+    end if
+
+    ! read grid dimensions
+    read(fid,*) Nx, Ny, NzEarth
+    if (Nx <= 0 .or. Ny <= 0 .or. NzEarth <= 0) then
+       call errStop('Invalid grid dimensions in covariance file '//cfile)
+    end if
+    CmSqrtBiHelm%Nx = Nx
+    CmSqrtBiHelm%Ny = Ny
+    CmSqrtBiHelm%NzEarth = NzEarth
+
+    ! read kappa (dimensionless, correlation length ~ 1/kappa cells)
+    read(fid,*) CmSqrtBiHelm%kappa
+    if (CmSqrtBiHelm%kappa <= 0.0_prec) then
+       call errStop('BiHelmholtz kappa must be positive in covariance file '//cfile)
+    end if
+
+    ! read solver controls
+    read(fid,*,iostat=istat) CmSqrtBiHelm%pcg_tol
+    if (istat /= 0 .or. CmSqrtBiHelm%pcg_tol <= 0.0_prec) then
+       call errStop('BiHelmholtz pcg_tol must be positive in covariance file '//cfile)
+    end if
+    read(fid,*,iostat=istat) CmSqrtBiHelm%pcg_maxIt
+    if (istat /= 0 .or. CmSqrtBiHelm%pcg_maxIt <= 0) then
+       call errStop('BiHelmholtz pcg_maxIt must be positive in covariance file '//cfile)
+    end if
+
+    ! read exception rules (order-independent mask-code pairs: smoothing
+    ! is turned off across faces between cells with these mask codes)
+    read(fid,*,iostat=istat) CmSqrtBiHelm%nrules
+    if (istat /= 0 .or. CmSqrtBiHelm%nrules < 0) then
+       call errStop('BiHelmholtz cov file must have nrules (>= 0) after pcg_maxIt')
+    end if
+    CmSqrtBiHelm%tearMatrix = .false.
+    if (CmSqrtBiHelm%nrules > 0) then
+       allocate(CmSqrtBiHelm%tearPairs(2, CmSqrtBiHelm%nrules), stat=istat)
+       if (istat /= 0) call errStop('Memory allocation failed for tearPairs')
+       do j = 1, CmSqrtBiHelm%nrules
+          read(fid,*) CmSqrtBiHelm%tearPairs(1,j), CmSqrtBiHelm%tearPairs(2,j)
+          if (CmSqrtBiHelm%tearPairs(1,j) < 0 .or. CmSqrtBiHelm%tearPairs(1,j) > 9 .or. &
+              CmSqrtBiHelm%tearPairs(2,j) < 0 .or. CmSqrtBiHelm%tearPairs(2,j) > 9) then
+             call errStop('Invalid mask code in tear rule (must be 0-9)')
+          end if
+          CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%tearPairs(1,j), CmSqrtBiHelm%tearPairs(2,j)) = .true.
+          CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%tearPairs(2,j), CmSqrtBiHelm%tearPairs(1,j)) = .true.
+       end do
+    end if
+
+    ! create and read the mask array
+    call read_iscalar(fid, CmSqrtBiHelm%mask)
+
+    close(fid)
+
+  end subroutine read_CmSqrt_BiHelm
+
+! *******************************************************************
+  subroutine create_CmSqrt_BiHelm(m, cfile)
+
+    ! Initializes the BiHelmholtz covariance. If cfile is provided, reads
+    ! configuration from file; otherwise uses defaults.
+
+    type (modelParam_t), intent(in)     :: m
+    character(*), intent(in), optional  :: cfile
+    logical                             :: exists
+
+    ! initialize dimensions
+    CmSqrtBiHelm%Nx = m%Nx
+    CmSqrtBiHelm%Ny = m%Ny
+    CmSqrtBiHelm%NzEarth = m%NzEarth
+
+    ! defaults
+    CmSqrtBiHelm%kappa = 0.5_prec
+    CmSqrtBiHelm%pcg_tol = 1.0e-7_prec
+    CmSqrtBiHelm%pcg_maxIt = 250
+
+    ! no exception rules by default
+    CmSqrtBiHelm%tearMatrix = .false.
+    CmSqrtBiHelm%nrules = 0
+    nullify(CmSqrtBiHelm%tearPairs)
+
+    call create_iscalar(m%grid, CmSqrtBiHelm%mask, CELL_EARTH)
+    CmSqrtBiHelm%mask%v = FREE
+
+    if (present(cfile)) then
+       inquire(FILE=cfile, EXIST=exists)
+       if (exists) then
+          call read_CmSqrt_BiHelm(cfile)
+       else
+          call errStop('Unable to find covariance file '//trim(cfile)//' in create_CmSqrt_BiHelm')
+       end if
+       if ((CmSqrtBiHelm%Nx /= m%Nx) .or. (CmSqrtBiHelm%Ny /= m%Ny) .or. &
+           (CmSqrtBiHelm%NzEarth /= m%NzEarth)) then
+          call errStop('Grid dimensions do not match in covariance file '//cfile)
+       end if
+    end if
+
+    ! assemble the sparse operator A = kappa^2 I - Delta
+    call assemble_A_BiHelm(m)
+
+    if (output_level > 3) then
+       write(6,*) 'create_CmSqrt_BiHelm: CovType=2, Nx=', CmSqrtBiHelm%Nx, &
+            ' Ny=', CmSqrtBiHelm%Ny, ' NzEarth=', CmSqrtBiHelm%NzEarth, &
+            ' nCells=', CmSqrtBiHelm%Nx * CmSqrtBiHelm%Ny * CmSqrtBiHelm%NzEarth
+       write(6,*) '  kappa (cell units)=', CmSqrtBiHelm%kappa, &
+            ' (correlation length ~', 1.0_prec/CmSqrtBiHelm%kappa, ' cells)'
+       write(6,*) '  pcg_tol=', CmSqrtBiHelm%pcg_tol, &
+            ' pcg_maxIt=', CmSqrtBiHelm%pcg_maxIt
+       write(6,*) '  operator nnz=', size(CmSqrtBiHelm%A%col)
+    end if
+
+    CmSqrtBiHelm%allocated = .true.
+
+  end subroutine create_CmSqrt_BiHelm
+
+! *******************************************************************
+  subroutine deall_CmSqrt_BiHelm()
+
+    integer  :: istat
+
+    call deall_spMatCSR(CmSqrtBiHelm%A)
+    call deall_iscalar(CmSqrtBiHelm%mask)
+    if (associated(CmSqrtBiHelm%tearPairs)) deallocate(CmSqrtBiHelm%tearPairs)
+    CmSqrtBiHelm%nrules = 0
+    CmSqrtBiHelm%tearMatrix = .false.
+    CmSqrtBiHelm%allocated = .false.
+
+  end subroutine deall_CmSqrt_BiHelm
+
+! *******************************************************************
+  subroutine assemble_A_BiHelm(m)
+
+    ! Assembles the sparse CSR operator A = kappa^2 I - Delta
+    ! over earth cells using a graph-Laplacian stencil in cell-index
+    ! space (unit weights).  This is consistent with the AR(1) smoother
+    ! which also operates in cell-index coordinates — correlation between
+    ! adjacent cells does not depend on physical grid spacing.
+    !
+    !   A = kappa^2 * I - L_graph
+    !
+    ! where L_graph has unit off-diagonal entries (all neighbors at
+    ! distance 1 in index space).  With kappa > 0 this guarantees a
+    ! well-conditioned PD operator whose eigenvalues are O(1) regardless
+    ! of the model's physical extent.
+    !
+    ! Exception rules (tearMatrix) optionally disable edges between
+    ! specific mask-code pairs, creating "tears" in the smoothing.
+    !
+    ! Counting pass first, then fill pass.
+
+    type (modelParam_t), intent(in) :: m
+    integer                         :: Nx, Ny, NzEarth, nCells, nzAir
+    integer                         :: i, j, k, kz, idx, idx_nb
+    integer                         :: nnz, nz, istat, p
+   real (kind=prec)                :: kappa2
+   real (kind=prec)                :: diagA
+    integer, allocatable            :: rowT(:)
+
+    Nx = m%Nx
+    Ny = m%Ny
+    NzEarth = m%NzEarth
+    nzAir = m%grid%nzAir
+    nCells = Nx * Ny * NzEarth
+    kappa2 = CmSqrtBiHelm%kappa**2
+
+    if (.not. m%grid%allocated) then
+       call errStop('Grid must be allocated before assemble_A_BiHelm')
+    end if
+
+    if (CmSqrtBiHelm%A%allocated) then
+       call deall_spMatCSR(CmSqrtBiHelm%A)
+    end if
+
+    ! Pass 1: count non-zeros per row
+    allocate(rowT(nCells+1), stat=istat)
+    rowT = 0
+    nz = 0
+    do k = 1, NzEarth
+       do j = 1, Ny
+          do i = 1, Nx
+             idx = (k-1)*Nx*Ny + (j-1)*Nx + i
+             nnz = 1
+             if (i > 1) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i-1,j,k))) nnz = nnz + 1
+             end if
+             if (i < Nx) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i+1,j,k))) nnz = nnz + 1
+             end if
+             if (j > 1) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i,j-1,k))) nnz = nnz + 1
+             end if
+             if (j < Ny) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i,j+1,k))) nnz = nnz + 1
+             end if
+             if (k > 1) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i,j,k-1))) nnz = nnz + 1
+             end if
+             if (k < NzEarth) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i,j,k+1))) nnz = nnz + 1
+             end if
+             rowT(idx) = nnz
+             nz = nz + nnz
+          end do
+       end do
+    end do
+
+    call create_spMatCSR(nCells, nCells, nz, CmSqrtBiHelm%A)
+
+    CmSqrtBiHelm%A%row(1) = 1
+    do idx = 2, nCells+1
+       CmSqrtBiHelm%A%row(idx) = CmSqrtBiHelm%A%row(idx-1) + rowT(idx-1)
+    end do
+    deallocate(rowT, stat=istat)
+
+    ! Pass 2: fill columns and values
+    do k = 1, NzEarth
+       kz = k + nzAir
+       do j = 1, Ny
+          do i = 1, Nx
+             idx = (k-1)*Nx*Ny + (j-1)*Nx + i
+             p = CmSqrtBiHelm%A%row(idx)
+
+             diagA = kappa2
+             if (i > 1) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i-1,j,k))) diagA = diagA + 1.0_prec
+             end if
+             if (i < Nx) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i+1,j,k))) diagA = diagA + 1.0_prec
+             end if
+             if (j > 1) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i,j-1,k))) diagA = diagA + 1.0_prec
+             end if
+             if (j < Ny) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i,j+1,k))) diagA = diagA + 1.0_prec
+             end if
+             if (k > 1) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i,j,k-1))) diagA = diagA + 1.0_prec
+             end if
+             if (k < NzEarth) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i,j,k+1))) diagA = diagA + 1.0_prec
+             end if
+
+             ! diagonal
+             CmSqrtBiHelm%A%col(p) = idx
+             CmSqrtBiHelm%A%val(p) = diagA
+             p = p + 1
+
+             ! X-left
+             if (i > 1) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i-1,j,k))) then
+                   idx_nb = (k-1)*Nx*Ny + (j-1)*Nx + (i-1)
+                   CmSqrtBiHelm%A%col(p) = idx_nb
+                   CmSqrtBiHelm%A%val(p) = -1.0_prec
+                   p = p + 1
+                end if
+             end if
+             ! X-right
+             if (i < Nx) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i+1,j,k))) then
+                   idx_nb = (k-1)*Nx*Ny + (j-1)*Nx + (i+1)
+                   CmSqrtBiHelm%A%col(p) = idx_nb
+                   CmSqrtBiHelm%A%val(p) = -1.0_prec
+                   p = p + 1
+                end if
+             end if
+             ! Y-left
+             if (j > 1) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i,j-1,k))) then
+                   idx_nb = (k-1)*Nx*Ny + (j-2)*Nx + i
+                   CmSqrtBiHelm%A%col(p) = idx_nb
+                   CmSqrtBiHelm%A%val(p) = -1.0_prec
+                   p = p + 1
+                end if
+             end if
+             ! Y-right
+             if (j < Ny) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i,j+1,k))) then
+                   idx_nb = (k-1)*Nx*Ny + j*Nx + i
+                   CmSqrtBiHelm%A%col(p) = idx_nb
+                   CmSqrtBiHelm%A%val(p) = -1.0_prec
+                   p = p + 1
+                end if
+             end if
+             ! Z-left
+             if (k > 1) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i,j,k-1))) then
+                   idx_nb = (k-2)*Nx*Ny + (j-1)*Nx + i
+                   CmSqrtBiHelm%A%col(p) = idx_nb
+                   CmSqrtBiHelm%A%val(p) = -1.0_prec
+                   p = p + 1
+                end if
+             end if
+             ! Z-right
+             if (k < NzEarth) then
+                if (.not. CmSqrtBiHelm%tearMatrix(CmSqrtBiHelm%mask%v(i,j,k), &
+                    CmSqrtBiHelm%mask%v(i,j,k+1))) then
+                   idx_nb = k*Nx*Ny + (j-1)*Nx + i
+                   CmSqrtBiHelm%A%col(p) = idx_nb
+                   CmSqrtBiHelm%A%val(p) = -1.0_prec
+                   p = p + 1
+                end if
+             end if
+
+          end do
+       end do
+    end do
+
+  end subroutine assemble_A_BiHelm
+
+! *******************************************************************
+  subroutine apply_A_BiHelm(v_in, v_out)
+
+    ! Sparse matvec: v_out = A * v_in over earth cells.
+
+    real (kind=prec), intent(in)  :: v_in(:,:,:)
+    real (kind=prec), intent(out) :: v_out(:,:,:)
+    integer                       :: Nx, Ny, NzEarth, nCells, i, j, k, idx
+    real (kind=prec), allocatable :: x(:), y(:)
+
+    Nx = size(v_in, 1)
+    Ny = size(v_in, 2)
+    NzEarth = size(v_in, 3)
+    nCells = Nx * Ny * NzEarth
+
+    allocate(x(nCells), y(nCells))
+
+    ! flatten 3D -> 1D
+    do k = 1, NzEarth
+       do j = 1, Ny
+          do i = 1, Nx
+             idx = (k-1)*Nx*Ny + (j-1)*Nx + i
+             x(idx) = v_in(i,j,k)
+          end do
+       end do
+    end do
+
+    ! CSR matvec via spOpTools
+    call RMATxRVEC(CmSqrtBiHelm%A, x, y)
+
+    ! unflatten 1D -> 3D
+    do k = 1, NzEarth
+       do j = 1, Ny
+          do i = 1, Nx
+             idx = (k-1)*Nx*Ny + (j-1)*Nx + i
+             v_out(i,j,k) = y(idx)
+          end do
+       end do
+    end do
+
+    deallocate(x, y)
+
+  end subroutine apply_A_BiHelm
+
+! *******************************************************************
+  subroutine apply_freeze_semantics_BiHelm(v)
+
+    ! Zeros out air (mask==0) and ocean (mask==9) cells.
+
+    real (kind=prec), intent(inout) :: v(:,:,:)
+    integer                         :: Nx, Ny, NzEarth, i, j, k
+
+    Nx = size(v, 1)
+    Ny = size(v, 2)
+    NzEarth = size(v, 3)
+
+    do k = 1, NzEarth
+       do j = 1, Ny
+          do i = 1, Nx
+             if (CmSqrtBiHelm%mask%v(i,j,k) == AIR .or. &
+                 CmSqrtBiHelm%mask%v(i,j,k) == OCEAN) then
+                v(i,j,k) = 0.0_prec
+             end if
+          end do
+       end do
+    end do
+
+  end subroutine apply_freeze_semantics_BiHelm
+
+! *******************************************************************
+  subroutine solve_A_BiHelm(rhs, sol, tol, maxIt, nIt, ok)
+
+    ! Solve A * sol = rhs using PCG (Jacobi preconditioner).
+
+    real (kind=prec), intent(in)  :: rhs(:,:,:)
+    real (kind=prec), intent(out) :: sol(:,:,:)
+    real (kind=prec), intent(in)  :: tol
+    integer, intent(in)           :: maxIt
+    integer, intent(out)          :: nIt
+    logical, intent(out)          :: ok
+
+    integer                       :: Nx, Ny, NzEarth, nCells
+    integer                       :: i, j, k, idx, it, istat
+    real (kind=prec), allocatable :: r(:), p(:), z(:), q(:), x(:), b(:)
+    real (kind=prec), allocatable :: diag(:)
+   real (kind=prec)              :: alpha, beta, rsold, rsnew, bnrm, denom
+    logical                       :: earlyExit
+
+    Nx = size(rhs, 1)
+    Ny = size(rhs, 2)
+    NzEarth = size(rhs, 3)
+    nCells = Nx * Ny * NzEarth
+
+    allocate(b(nCells), x(nCells), r(nCells), p(nCells), z(nCells), q(nCells), stat=istat)
+    if (istat /= 0) call errStop('Memory allocation failed in solve_A_BiHelm')
+    allocate(diag(nCells), stat=istat)
+    if (istat /= 0) call errStop('Memory allocation failed in solve_A_BiHelm (diag)')
+
+    ! flatten rhs
+    do k = 1, NzEarth
+       do j = 1, Ny
+          do i = 1, Nx
+             idx = (k-1)*Nx*Ny + (j-1)*Nx + i
+             b(idx) = rhs(i,j,k)
+          end do
+       end do
+    end do
+
+    ! extract diagonal for Jacobi preconditioner
+    call diag_Real(CmSqrtBiHelm%A, diag)
+
+    ! initial guess = 0
+    x = 0.0_prec
+
+    ! r = b - A * 0 = b
+    r = b
+
+    ! solve M * z = r  (Jacobi: z = r ./ diag)
+    do idx = 1, nCells
+       if (abs(diag(idx)) > R_TINY) then
+          z(idx) = r(idx) / diag(idx)
+       else
+          z(idx) = 0.0_prec
+       end if
+    end do
+
+    p = z
+   rsold = dot_product(r, z)
+    bnrm = sqrt(dot_product(b, b))
+
+    if (output_level > 3) then
+       write(6,*) 'solve_A_BiHelm: starting PCG, tol=', tol, ' maxIt=', maxIt, ' bnrm=', bnrm
+    end if
+
+    if (bnrm < R_TINY) then
+       sol = 0.0_prec
+       ok = .true.
+       nIt = 0
+       deallocate(b, x, r, p, z, q, diag)
+       return
+    end if
+
+    if (rsold /= rsold) then
+       sol = 0.0_prec
+       ok = .false.
+       nIt = 0
+       deallocate(b, x, r, p, z, q, diag)
+       return
+    end if
+
+    ok = .false.
+    earlyExit = .false.
+    do it = 1, maxIt
+       ! q = A * p
+       call RMATxRVEC(CmSqrtBiHelm%A, p, q)
+
+        denom = dot_product(p, q)
+        if ((abs(denom) < R_TINY) .or. (denom /= denom)) then
+           ok = .false.
+           earlyExit = .true.
+           nIt = it
+           exit
+        end if
+
+        alpha = rsold / denom
+        if (alpha /= alpha) then
+           ok = .false.
+           earlyExit = .true.
+           nIt = it
+           exit
+        end if
+
+       x = x + alpha * p
+       r = r - alpha * q
+
+       ! check convergence
+        if (sqrt(dot_product(r, r)) / bnrm < tol) then
+           if (output_level > 4) then
+              write(6,*) 'solve_A_BiHelm: it=', it, &
+                   ' rel_res=', sqrt(dot_product(r, r)) / bnrm, ' (converged)'
+           end if
+           ok = .true.
+           nIt = it
+           exit
+        end if
+
+        if (output_level > 4) then
+           write(6,*) 'solve_A_BiHelm: it=', it, &
+                ' rel_res=', sqrt(dot_product(r, r)) / bnrm
+        end if
+
+        ! solve M * z = r (Jacobi)
+       do idx = 1, nCells
+          if (abs(diag(idx)) > R_TINY) then
+             z(idx) = r(idx) / diag(idx)
+          else
+             z(idx) = 0.0_prec
+          end if
+       end do
+
+        rsnew = dot_product(r, z)
+        if (rsnew /= rsnew) then
+           ok = .false.
+           earlyExit = .true.
+           nIt = it
+           exit
+        end if
+        if ((abs(rsold) < R_TINY) .or. (rsold /= rsold)) then
+           ok = .false.
+           earlyExit = .true.
+           nIt = it
+           exit
+        end if
+
+        beta = rsnew / rsold
+        if (beta /= beta) then
+           ok = .false.
+           earlyExit = .true.
+           nIt = it
+           exit
+        end if
+
+       p = z + beta * p
+       rsold = rsnew
+    end do
+
+    if (.not. ok .and. .not. earlyExit) then
+       nIt = maxIt
+    end if
+
+    if (output_level > 3) then
+       if (ok) then
+          write(6,*) 'solve_A_BiHelm: converged in ', nIt, &
+               ' iterations, rel_res=', sqrt(dot_product(r, r)) / bnrm
+       else
+          write(6,*) 'solve_A_BiHelm: FAILED at it=', nIt, &
+               ' rel_res=', sqrt(dot_product(r, r)) / bnrm
+       end if
+    end if
+
+    ! unflatten solution
+    do k = 1, NzEarth
+       do j = 1, Ny
+          do i = 1, Nx
+             idx = (k-1)*Nx*Ny + (j-1)*Nx + i
+             sol(i,j,k) = x(idx)
+          end do
+       end do
+    end do
+
+    deallocate(b, x, r, p, z, q, diag)
+
+  end subroutine solve_A_BiHelm
+
+! *******************************************************************
+  function multBy_CmSqrt_BiHelm(mhat) result(dm)
+
+    ! K = A^{-1}: solve A * dm = mhat
+
+    type (modelParam_t), intent(in) :: mhat
+    type (modelParam_t)             :: dm
+    integer                         :: nIt
+    logical                         :: ok
+
+    if (.not. CmSqrtBiHelm%allocated) then
+       call create_CmSqrt_BiHelm(mhat)
+    end if
+
+    dm = mhat
+
+    call solve_A_BiHelm(mhat%cellCond%v, dm%cellCond%v, &
+         CmSqrtBiHelm%pcg_tol, CmSqrtBiHelm%pcg_maxIt, nIt, ok)
+
+    if (.not. ok) then
+       call errStop('PCG failed to converge in multBy_CmSqrt_BiHelm')
+    end if
+
+    call apply_freeze_semantics_BiHelm(dm%cellCond%v)
+
+    dm%temporary = .true.
+
+  end function multBy_CmSqrt_BiHelm
+
+! *******************************************************************
+  function multBy_Cm_BiHelm(mhat) result(dm)
+
+    ! C_m = A^{-2}: two solves with A
+
+    type (modelParam_t), intent(in) :: mhat
+    type (modelParam_t)             :: dm, tmp
+    integer                         :: nIt
+    logical                         :: ok
+
+    if (.not. CmSqrtBiHelm%allocated) then
+       call create_CmSqrt_BiHelm(mhat)
+    end if
+
+    tmp = mhat
+    call solve_A_BiHelm(mhat%cellCond%v, tmp%cellCond%v, &
+         CmSqrtBiHelm%pcg_tol, CmSqrtBiHelm%pcg_maxIt, nIt, ok)
+
+    if (.not. ok) then
+       call errStop('PCG failed to converge in multBy_Cm_BiHelm (first solve)')
+    end if
+
+    dm = tmp
+    call solve_A_BiHelm(tmp%cellCond%v, dm%cellCond%v, &
+         CmSqrtBiHelm%pcg_tol, CmSqrtBiHelm%pcg_maxIt, nIt, ok)
+
+    if (.not. ok) then
+       call errStop('PCG failed to converge in multBy_Cm_BiHelm (second solve)')
+    end if
+
+    call apply_freeze_semantics_BiHelm(dm%cellCond%v)
+
+    dm%temporary = .true.
+    call deall_modelParam(tmp)
+
+  end function multBy_Cm_BiHelm
+
+! *******************************************************************
+  function multBy_CmSqrtInv_BiHelm(dm) result(mhat)
+
+    ! K^{-1} = A: one sparse matvec
+
+    type (modelParam_t), intent(in) :: dm
+    type (modelParam_t)             :: mhat
+
+    if (.not. CmSqrtBiHelm%allocated) then
+       call create_CmSqrt_BiHelm(dm)
+    end if
+
+    mhat = dm
+    call apply_A_BiHelm(dm%cellCond%v, mhat%cellCond%v)
+
+    call apply_freeze_semantics_BiHelm(mhat%cellCond%v)
+
+    mhat%temporary = .true.
+
+  end function multBy_CmSqrtInv_BiHelm

--- a/f90/3D_MT/modelParam/modelCov/RecursiveAR.hd
+++ b/f90/3D_MT/modelParam/modelCov/RecursiveAR.hd
@@ -1,5 +1,12 @@
 !----------------------------------------------------------------------!
 ! 3D_MT model covariance by Gary Egbert and Anna Kelbert: definitions. !
+!                                                                      !
+!   Unified cov file format (line 17):                                !
+!     Nx Ny NzEarth FileType   (3 ints = legacy AR, 4 ints = new)    !
+!     Sx, Sy, Sz (smoothing parameters)                               !
+!     N (number of smoothing passes)                                   !
+!     nrules, mask1 mask2 smoothing (exception rules, 3 per rule)     !
+!     mask blocks (read_iscalar format)                                !
 !----------------------------------------------------------------------!
 
 ! 1) modelCov_t data type with private attributes

--- a/f90/3D_MT/modelParam/modelCov/RecursiveAR.hd
+++ b/f90/3D_MT/modelParam/modelCov/RecursiveAR.hd
@@ -45,7 +45,7 @@
 
 ! 3) public procedures to create, deallocate and multiply by CmSqrt
 
-  public    :: create_CmSqrt, deall_CmSqrt, multBy_CmSqrt, read_CmSqrt,multBy_Cm
+  public    :: create_CmSqrt_AR, deall_CmSqrt_AR, multBy_CmSqrt_AR, read_CmSqrt_AR, multBy_Cm_AR
 
 ! 4) any private procedures required for the model covariance
 

--- a/f90/3D_MT/modelParam/modelCov/RecursiveAR.inc
+++ b/f90/3D_MT/modelParam/modelCov/RecursiveAR.inc
@@ -22,7 +22,7 @@
 
     dm = mhat
 
-    call RecursiveAR(mhat%cellCond%v,dm%cellCond%v,2*CmSqrt%N)
+    call RecursiveAR(mhat%cellCond%v,dm%cellCond%v,2)
 
     dm%temporary = .true.
 
@@ -211,7 +211,7 @@
 	   read(fid,*) CmSqrt%N
 	else
 	   ! fileType=2 with CovType=1 selected: read mask, use AR defaults
-	   write(0,*) 'Warning: BiHelmholtz cov file read with CovType=1.'
+ 	   write(0,*) 'Warning: H2 cov file read with CovType=1.'
 	   write(0,*) '  Using AR defaults for Sx, Sy, Sz, N.'
 	   allocate(tempSx(NzEarth), tempSy(NzEarth), STAT=istat)
 	   read(fid,*) tempSx

--- a/f90/3D_MT/modelParam/modelCov/RecursiveAR.inc
+++ b/f90/3D_MT/modelParam/modelCov/RecursiveAR.inc
@@ -182,6 +182,9 @@
 
     integer       			 :: Nx, Ny, NzEarth, nrules, nS, i, j, k, n, istat
     integer                  :: fid = 30
+    integer                  :: fileType
+    real (kind=prec), allocatable :: tempSx(:), tempSy(:)
+    real (kind=prec)         :: tempN, tempSz
 
 	if (.not. CmSqrt%allocated) then
 		call errStop('Model covariance must be allocated before reading from file in read_CmSqrt')
@@ -194,19 +197,34 @@
        read(fid,*)
     end do
 
-	! read grid dimensions
-	read(fid,*) Nx,Ny,NzEarth
+	! detect filetype and read grid dimensions from line 17
+	call detect_cov_filetype(fid, Nx, Ny, NzEarth, fileType)
 	CmSqrt%Nx = Nx
 	CmSqrt%Ny = Ny
 	CmSqrt%NzEarth = NzEarth
 
-	! read smoothing parameters
-    read(fid,*) CmSqrt%Sx
-    read(fid,*) CmSqrt%Sy
-    read(fid,*) CmSqrt%Sz
-
-	! read number of times to apply the smoothing
-	read(fid,*) CmSqrt%N
+	if (fileType == 1) then
+	   ! normal AR read: read smoothing parameters and N
+	   read(fid,*) CmSqrt%Sx
+	   read(fid,*) CmSqrt%Sy
+	   read(fid,*) CmSqrt%Sz
+	   read(fid,*) CmSqrt%N
+	else
+	   ! fileType=2 with CovType=1 selected: read mask, use AR defaults
+	   write(0,*) 'Warning: BiHelmholtz cov file read with CovType=1.'
+	   write(0,*) '  Using AR defaults for Sx, Sy, Sz, N.'
+	   allocate(tempSx(NzEarth), tempSy(NzEarth), STAT=istat)
+	   read(fid,*) tempSx
+	   read(fid,*) tempSy
+	   read(fid,*) tempSz
+	   deallocate(tempSx, tempSy, STAT=istat)
+	   ! skip N, kappa, pcg_tol, pcg_maxIt (parameter array for CovType=2)
+	   read(fid,*) tempN, tempSz, tempSz, tempSz
+	   CmSqrt%Sx = 0.3
+	   CmSqrt%Sy = 0.3
+	   CmSqrt%Sz = 0.3
+	   CmSqrt%N = 1
+	end if
 
 	! read exception rules for smoothing across surfaces
     read(fid,*) nrules

--- a/f90/3D_MT/modelParam/modelCov/RecursiveAR.inc
+++ b/f90/3D_MT/modelParam/modelCov/RecursiveAR.inc
@@ -4,7 +4,7 @@
 ! Recursive autoregression.                                            !
 !----------------------------------------------------------------------!
 ! *******************************************************************
-  function multBy_Cm(mhat) result (dm)
+  function multBy_Cm_AR(mhat) result (dm)
 
    ! Multiplies by the full model covariance,
    ! which is viewed as a smoothing operator. Intended
@@ -17,21 +17,21 @@
     type (modelParam_t)				    :: dm
 
     if (.not. CmSqrt%allocated) then
-    	call create_CmSqrt(mhat)
+    	call create_CmSqrt_AR(mhat)
     end if
 
     dm = mhat
 
-    call RecursiveAR(mhat%cellCond%v,dm%cellCond%v,2)
+    call RecursiveAR(mhat%cellCond%v,dm%cellCond%v,2*CmSqrt%N)
 
     dm%temporary = .true.
 
-  end function multBy_Cm
+  end function multBy_Cm_AR
 
 ! *******************************************************************
 
 ! *******************************************************************
-  function multBy_CmSqrt(mhat) result (dm)
+  function multBy_CmSqrt_AR(mhat) result (dm)
 
    ! Multiplies by the square root of the model covariance,
    ! which is viewed as a smoothing operator. Intended
@@ -44,7 +44,7 @@
     type (modelParam_t)				    :: dm
 
     if (.not. CmSqrt%allocated) then
-    	call create_CmSqrt(mhat)
+    	call create_CmSqrt_AR(mhat)
     end if
 
     dm = mhat
@@ -53,10 +53,10 @@
 
     dm%temporary = .true.
 
-  end function multBy_CmSqrt
+  end function multBy_CmSqrt_AR
 
 ! *******************************************************************
-  function multBy_CmSqrtInv(dm) result (mhat)
+  function multBy_CmSqrtInv_AR(dm) result (mhat)
 
    ! Multiplies by the inverse square root of the model covariance,
    ! which is viewed as a roughening operator. Intended
@@ -69,7 +69,7 @@
     type (modelParam_t)                 :: mhat
 
     if (.not. CmSqrt%allocated) then
-        call create_CmSqrt(dm)
+        call create_CmSqrt_AR(dm)
     end if
 
     mhat = dm
@@ -78,10 +78,10 @@
 
     mhat%temporary = .true.
 
-  end function multBy_CmSqrtInv
+  end function multBy_CmSqrtInv_AR
 
 ! *******************************************************************
-  subroutine create_CmSqrt(m,cfile)
+  subroutine create_CmSqrt_AR(m,cfile)
 
   	! Initializes CmSqrt variable stored in RecursiveAR.hd. If cfile
   	! is specified, gets this information from file.
@@ -111,7 +111,7 @@
 		! attempt to read CmSqrt from cfile
 	    inquire(FILE=cfile,EXIST=exists)
 	    if (exists) then
-	      call read_CmSqrt(cfile)
+	      call read_CmSqrt_AR(cfile)
 	    else
 	      call errStop('Unable to find the input covariance file '//trim(cfile)//' in create_CmSqrt')
 	    end if
@@ -121,10 +121,10 @@
 	    end if
     end if
 
-  end subroutine create_CmSqrt
+  end subroutine create_CmSqrt_AR
 
 ! *******************************************************************
-  subroutine deall_CmSqrt()
+  subroutine deall_CmSqrt_AR()
 
     integer                             :: istat
 
@@ -133,7 +133,7 @@
     call deall_iscalar(CmSqrt%mask)
     CmSqrt%allocated = .false.
 
-  end subroutine deall_CmSqrt
+  end subroutine deall_CmSqrt_AR
 
 ! *******************************************************************
 !
@@ -156,7 +156,7 @@
 !| 8. Two integer layer indices and Nx x Ny block of masks, repeated as needed.|
 !+-----------------------------------------------------------------------------+
 
-  subroutine read_CmSqrt(cfile)
+  subroutine read_CmSqrt_AR(cfile)
 
 	! The minimal covariance information includes the AR parameters
 	! alpha(k), beta(k) for smoothing in x, y directions and gamma for
@@ -271,7 +271,7 @@
     ! now, truncate the smoothing vector to the correct number of components
     call reall_sparsevecc(nS, CmSqrt%S)
 
-  end subroutine read_CmSqrt
+  end subroutine read_CmSqrt_AR
 
 ! *******************************************************************
 !

--- a/f90/3D_MT/modelParam/modelParamIO.f90
+++ b/f90/3D_MT/modelParam/modelParamIO.f90
@@ -1,7 +1,9 @@
 submodule (ModelSpace) ModelSpaceIO
 
     use utilities
+#ifdef MPI
     use Declaration_MPI
+#endif
     !%use ModelSpace
 
     implicit none
@@ -147,9 +149,11 @@ contains
         character(len=*), intent(in) :: cfile
         character(len=*), intent(in), optional :: comment
 
+#ifdef MPI
         if (taskid /= 0) then
             return
         end if
+#endif
 
         select case(OUTPUT_FILE_TYPE)
             case (WS_FILE_TYPE)

--- a/f90/CONFIG/configure
+++ b/f90/CONFIG/configure
@@ -406,9 +406,11 @@ case $solver in
         source_dirs=( ${source_dirs[@]} ${MF_DIRS[@]} )
         ;;
     SP | sp)
+        FFLAGS="$FFLAGS -DSP_FORM"
         source_dirs=( ${source_dirs[@]} ${SP_DIRS[@]} )
         ;;
     SP2 | sp2)
+        FFLAGS="$FFLAGS -DSP_FORM"
         source_dirs=( ${source_dirs[@]} ${SP2_DIRS[@]} )
         ;;
 esac

--- a/f90/INV/NLCG.f90
+++ b/f90/INV/NLCG.f90
@@ -496,7 +496,7 @@ Contains
    call deall_modelParam(h)
    call deall_modelParam(gPrev)
    call deall_solnVectorMTX(eAll)
-   call ModEM_timers_destory('NLCG Iteration')
+   call ModEM_timers_destroy('NLCG Iteration')
 
    end subroutine NLCGsolver
 

--- a/f90/MPI/Main_MPI.f90
+++ b/f90/MPI/Main_MPI.f90
@@ -1425,7 +1425,7 @@ end subroutine Master_job_keep_prev_eAll
 !################### Master_job_Distribute_userdef_control###################
 Subroutine Master_job_Distribute_userdef_control(ctrl, comm)
      implicit none
-     type(userdef_control), intent(in) :: ctrl
+     type(userdef_control), intent(inout) :: ctrl
      integer, intent(in), optional :: comm
      !local
      character(20)                 :: which_proc

--- a/f90/Mod3DMT.f90
+++ b/f90/Mod3DMT.f90
@@ -483,7 +483,7 @@ program Mod3DMT
 #else
       call ModEM_timers_report(6)
 #endif 
-      call ModEM_timers_destory_all()
+      call ModEM_timers_destroy_all()
 
 
 end program

--- a/f90/Mod3DMT.f90
+++ b/f90/Mod3DMT.f90
@@ -51,6 +51,7 @@ program Mod3DMT
           ! OR readStartup(rFile_Startup,cUserDef)
           write(6,*)'I am a PARALLEL version'
           call process_optional_namelist(cUserDef)
+          call finalize_covType(cUserDef)
           call Master_job_Distribute_userdef_control(cUserDef)
           open(ioMPI,file=cUserDef%wFile_MPI)
           write(ioMPI,*) 'Total Number of nodes= ', number_of_workers
@@ -60,6 +61,7 @@ program Mod3DMT
 #else
       call parseArgs('Mod3DMT',cUserDef) ! OR readStartup(rFile_Startup,cUserDef)
       call process_optional_namelist(cUserDef)
+      call finalize_covType(cUserDef)
       write(6,*)'I am a SERIAL version'
 #endif
  

--- a/f90/UTILS/ModEM_timers.f90
+++ b/f90/UTILS/ModEM_timers.f90
@@ -49,7 +49,7 @@ module ModEM_timers
 
     public ModEM_timer_t
 
-    public ModEM_timers_create, ModEM_timers_destory, ModEM_timers_destory_all
+    public ModEM_timers_create, ModEM_timers_destroy, ModEM_timers_destroy_all
     public ModEM_timers_start, ModEM_timers_stop, ModEM_timers_stop_all
     public ModEM_timers_exist, ModEM_timers_get
     public ModEM_timers_print, ModEM_timers_print_all, ModEM_timers_report
@@ -279,7 +279,7 @@ module ModEM_timers
 
     end subroutine ModEM_timers_stop_all
 
-    subroutine ModEM_timers_destory(timer_name)
+    subroutine ModEM_timers_destroy(timer_name)
 
         implicit none
 
@@ -312,9 +312,9 @@ module ModEM_timers
             cur => cur % next
         end do
 
-    end subroutine ModEM_timers_destory
+    end subroutine ModEM_timers_destroy
 
-    subroutine ModEM_timers_destory_all()
+    subroutine ModEM_timers_destroy_all()
 
         implicit none
 
@@ -323,11 +323,11 @@ module ModEM_timers
         cur => timers % next
 
         do while (associated(cur))
-            call ModEM_timers_destory(cur % name)
+            call ModEM_timers_destroy(cur % name)
             cur => cur % next
         end do
 
-    end subroutine ModEM_timers_destory_all
+    end subroutine ModEM_timers_destroy_all
 
     subroutine ModEM_timers_print(timer_name, file)
 

--- a/f90/UserCtrl.f90
+++ b/f90/UserCtrl.f90
@@ -268,7 +268,7 @@ Contains
         write(*,*) ' -x  rFile_Model rFile_Data wFile_dModel [rFile_fwdCtrl]'
         write(*,*) '  Multiplies a data vector by J^T to output models for each transmitter'
         write(*,*) '[APPLY_COV]'
-        write(*,*) ' -C FWD rFile_Model wFile_Model [rFile_Cov rFile_Prior]'
+        write(*,*) ' -C FWD rFile_Model wFile_Model [rFile_Cov [rFile_Prior [CovType]]]'
         write(*,*) '  Applies the model covariance to produce a smooth model output'
         write(*,*) '  Optionally, also specify the prior model to compute resistivities'
         write(*,*) '  from model perturbation: m = C_m^{1/2} \\tilde{m} + m_0'
@@ -514,6 +514,7 @@ Contains
            write(0,*) 'Exit search when rms is less than  : 1.05'
            write(0,*) 'Exit when lambda is less than      : 1.0e-4'
            write(0,*) 'Maximum number of iterations       : 120'
+           write(0,*) 'Covariance backend CovType (optional): 1'
            write(0,*)
            write(0,*) 'NOTE: change the maximum number of iterations to '
            write(0,*) '    a value < 20 if DCG is the inverse algorithm'
@@ -530,6 +531,12 @@ Contains
            write(0,*) 'Air layers mirror|fixed height|read from file : fixed height'
            write(0,*) 'Number of air layers and max height in km     : 12 1000'
            write(0,*) 'Forward solver method PCG|QMR|TFQMR|BICG      : QMR'
+           write(0,*)
+           write(0,*) 'CovType=1 (AR, default): recursive exponential smoother.'
+           write(0,*) '  AR cov file format: 16-line header, N, Sx/Sy/Sz/S blocks, mask.'
+           write(0,*) 'CovType=2 (Bi-Helmholtz):  isotropic Bi-Helmholtz smoother.'
+           write(0,*) '  Bi-Helmholtz cov file format: 16-line header, CovType=2, Nx Ny NzEarth,'
+            write(0,*) '    kappa (dimensionless, cells), pcg_tol, pcg_maxIt, mask blocks.'
            write(0,*)
            write(0,*) 'Optionally, may also supply'
            write(0,*)
@@ -589,19 +596,29 @@ Contains
 
       case (APPLY_COV) ! C
         if (narg < 3) then
-           write(0,*) 'Usage: -C  [FWD|INV] rFile_Model wFile_Model [rFile_Cov rFile_Prior]'
+           write(0,*) 'Usage: -C [FWD|INV] rFile_Model wFile_Model [rFile_Cov [rFile_Prior [CovType]]]'
            write(0,*)
-           write(0,*) ' -C FWD rFile_Model wFile_Model [rFile_Cov rFile_Prior]'
+           write(0,*) ' -C FWD rFile_Model wFile_Model [rFile_Cov [rFile_Prior [CovType]]]'
            write(0,*) '  Applies the model covariance to produce a smooth model output'
            write(0,*) '  Optionally, also specify the prior model to compute resistivities'
            write(0,*) '  from model perturbation: m = C_m^{1/2} \\tilde{m} + m_0'
            write(0,*)
-           write(0,*) ' -C INV rFile_Model wFile_Model [rFile_Cov rFile_Prior]'
+           write(0,*) ' -C INV rFile_Model wFile_Model [rFile_Cov [rFile_Prior [CovType]]]'
            write(0,*) '  Applies the inverse of model covariance (if implemented)'
            write(0,*) '  Optionally, also specify the prior model to compute starting'
            write(0,*) '  perturbation for the inversion: \\tilde{m} = C_m^{-1/2} (m - m_0)'
            write(0,*) '  WARNING: may be poorly conditioned if the smoothing is too strong;'
            write(0,*) '  always check your model for white noise after using this option.'
+           write(0,*)
+           write(0,*) 'Note -C options can be run in serial only.'
+           write(0,*) 'CovType=1 (AR, default): recursive exponential smoother.'
+           write(0,*) '  AR cov file format: 16-line header, N, Sx/Sy/Sz/S blocks, mask.'
+           write(0,*) 'CovType=2 (Bi-Helmholtz):  isotropic Bi-Helmholtz smoother.'
+           write(0,*) '  Bi-Helmholtz cov file format: 16-line header, CovType=2, Nx Ny NzEarth,'
+           write(0,*) '    kappa (dimensionless, cells), pcg_tol, pcg_maxIt, mask blocks.'
+           write(0,*)
+            write(0,*) 'The optional CovType argument selects the covariance backend:'
+           write(0,*) '  1 = AR (default), 2 = Bi-Helmholtz.'
            call ModEM_abort()
         else
         ctrl%option = temp(1)
@@ -613,6 +630,12 @@ Contains
         end if
         if (narg > 4) then
             ctrl%rFile_Prior = temp(5)
+        end if
+        if (narg > 5) then
+            read(temp(6), *, iostat=istat) ctrl%CovType
+            if (istat /= 0 .or. (ctrl%CovType /= 1 .and. ctrl%CovType /= 2)) then
+               call errStop('Invalid CovType for -C: must be 1 or 2')
+            end if
         end if
 
       case (DATA_FROM_E) ! d
@@ -945,13 +968,15 @@ Contains
      integer :: iostat
      integer :: output_level_int
 
-     ! Namelist - &settings - section
-     character (len=80) :: output_level
-     character (len=256) :: iomsg
+      ! Namelist - &settings - section
+      character (len=80) :: output_level
+      integer            :: CovType
+      character (len=256) :: iomsg
 
-     namelist /settings/ output_level
+      namelist /settings/ output_level, CovType
 
-     output_level = 'regular'
+      output_level = 'regular'
+      CovType = ctrl % CovType
 
      read(nl_fid, nml=settings, iostat=iostat, iomsg=iomsg)
      if (iostat /= 0) then
@@ -967,7 +992,9 @@ Contains
         call ModEM_abort()
      end if
 
-     write(0,*) "Optional namelist section '&settings' was read!"
+      write(0,*) "Optional namelist section '&settings' was read!"
+      ! NOTE: CovType namelist field is accepted but no longer processed.
+      ! CovType override sources (low->high priority): default(1) -> CLI 6th arg (-C) -> inv-ctrl 9th line (-I).
 
      ! Process output_level
      select case (output_level) ! Determine output_level number for comparision in CL arg
@@ -1027,6 +1054,8 @@ Contains
       write(nl_fid, *) "&settings"
       write(nl_fid, *) "    ! 'output_level' below overrides -V passed in on the command line"
       write(nl_fid, *) "    output_level = 'regular'"
+      write(nl_fid, *) "    ! CovType: 1 = AR (default), 2 = Bi-Helmholtz. Overrides -C CLI 6th arg, overridden by inv-ctrl 9th line."
+      write(nl_fid, *) "    CovType = 1"
       write(nl_fid, *) "/"
 
   end subroutine gen_nml_section_settings
@@ -1086,6 +1115,96 @@ Contains
       write(nl_fid, *) '/'
 
   end subroutine gen_nml_section_grid 
+
+! *******************************************************************
+! Reads CovType from an inversion control file (*.inv).
+! Expected format: "Covariance backend CovType (optional): <1|2>"
+! on the 9th line of the file (after 8 mandatory lines).
+! Returns found=.true. if a valid CovType override was read.
+  subroutine read_covType_from_file(rFile, covType, found)
+
+   implicit none
+   character(*), intent(in)                    :: rFile
+   integer, intent(inout)                      :: covType
+   logical, intent(out)                        :: found
+   integer                                     :: iu, ios, i, parsedCovType, colonPos
+   logical                                     :: exists
+   character(256)                              :: line
+
+   found = .false.
+
+   if (len_trim(rFile) <= 1) return
+   if (trim(rFile) == 'n') return
+
+   inquire(FILE=rFile, EXIST=exists)
+   if (.not. exists) return
+
+   iu = 98
+   open(unit=iu, file=rFile, status='old', iostat=ios)
+   if (ios /= 0) return
+
+   ! Skip required first 8 lines in inversion control format.
+   do i = 1, 8
+      read(iu, '(a)', iostat=ios) line
+      if (ios /= 0) then
+         close(iu)
+         return
+      end if
+   end do
+
+   ! Optional 9th line: CovType selector, parsed from text after ':'
+   read(iu, '(a)', iostat=ios) line
+   if (ios == 0) then
+      colonPos = index(line, ':')
+      if (colonPos > 0) then
+         read(line(colonPos+1:), *, iostat=ios) parsedCovType
+         if (ios == 0) then
+            if ((parsedCovType == 1) .or. (parsedCovType == 2)) then
+               covType = parsedCovType
+               found = .true.
+            else
+               write(0,*) 'Warning: invalid CovType in inverse control file (expected 1 or 2): ', parsedCovType
+            end if
+         end if
+      end if
+   end if
+
+   close(iu)
+
+  end subroutine read_covType_from_file
+
+! *******************************************************************
+! Finalizes CovType in ctrl by applying overrides from the inversion
+! control file (*.inv, 9th line). This is the highest-priority source:
+!
+!   Priority (low -> high):
+!     1) default (1) in initUserCtrl
+!     2) -C CLI optional 6th arg (APPLY_COV only)
+!     3) namelist.modem.nl &settings section
+!     4) inversion control file 9th line (-I only)
+!
+! Call this after parseArgs and process_optional_namelist, before
+! initGlobalData invokes set_CovType(ctrl%CovType).
+  subroutine finalize_covType(ctrl)
+
+   implicit none
+   type(userdef_control), intent(inout) :: ctrl
+
+   integer                              :: covTypeRead
+   logical                              :: found
+
+   ! Only INVERSE jobs have an inversion control file with a CovType line.
+   if (ctrl%job == INVERSE) then
+      call read_covType_from_file(ctrl%rFile_invCtrl, covTypeRead, found)
+      if (found) then
+         ctrl%CovType = covTypeRead
+         if (ctrl%output_level > 0) then
+            write(0,*) 'Setting CovType from inversion control file: ', covTypeRead
+         end if
+      end if
+   end if
+
+  end subroutine finalize_covType
 
 
 end module UserCtrl

--- a/f90/UserCtrl.f90
+++ b/f90/UserCtrl.f90
@@ -134,7 +134,7 @@ Contains
   	ctrl%lambda = 10.
   	ctrl%eps = 1.0e-7
   	ctrl%delta = 0.05
-    ! 1 for AR (default), 2 for Bi-Helmholtz
+    ! 1 for AR (default), 2 for H2 (Bi-Helmholtz)
     ctrl%CovType = 1
   	ctrl%output_level = 3	
 	ctrl%prefix = 'n'
@@ -534,8 +534,8 @@ Contains
            write(0,*)
            write(0,*) 'CovType=1 (AR, default): recursive exponential smoother.'
            write(0,*) '  AR cov file format: 16-line header, N, Sx/Sy/Sz/S blocks, mask.'
-           write(0,*) 'CovType=2 (Bi-Helmholtz):  isotropic Bi-Helmholtz smoother.'
-           write(0,*) '  Bi-Helmholtz cov file format: 16-line header, CovType=2, Nx Ny NzEarth,'
+           write(0,*) 'CovType=2 (H2 / Bi-Helmholtz):  isotropic H2 smoother.'
+           write(0,*) '  H2 cov file format: 16-line header, CovType=2, Nx Ny NzEarth,'
             write(0,*) '    kappa (dimensionless, cells), pcg_tol, pcg_maxIt, mask blocks.'
            write(0,*)
            write(0,*) 'Optionally, may also supply'
@@ -613,12 +613,12 @@ Contains
            write(0,*) 'Note -C options can be run in serial only.'
            write(0,*) 'CovType=1 (AR, default): recursive exponential smoother.'
            write(0,*) '  AR cov file format: 16-line header, N, Sx/Sy/Sz/S blocks, mask.'
-           write(0,*) 'CovType=2 (Bi-Helmholtz):  isotropic Bi-Helmholtz smoother.'
-           write(0,*) '  Bi-Helmholtz cov file format: 16-line header, CovType=2, Nx Ny NzEarth,'
+           write(0,*) 'CovType=2 (H2 / Bi-Helmholtz):  isotropic H2 smoother.'
+           write(0,*) '  H2 cov file format: 16-line header, CovType=2, Nx Ny NzEarth,'
            write(0,*) '    kappa (dimensionless, cells), pcg_tol, pcg_maxIt, mask blocks.'
            write(0,*)
             write(0,*) 'The optional CovType argument selects the covariance backend:'
-           write(0,*) '  1 = AR (default), 2 = Bi-Helmholtz.'
+           write(0,*) '  1 = AR (default), 2 = H2 (Bi-Helmholtz).'
            call ModEM_abort()
         else
         ctrl%option = temp(1)
@@ -968,15 +968,15 @@ Contains
      integer :: iostat
      integer :: output_level_int
 
-      ! Namelist - &settings - section
-      character (len=80) :: output_level
-      integer            :: CovType
-      character (len=256) :: iomsg
+     ! Namelist - &settings - section
+     character (len=80) :: output_level
+     integer            :: CovType
+     character (len=256) :: iomsg
 
-      namelist /settings/ output_level, CovType
+     namelist /settings/ output_level, CovType
 
-      output_level = 'regular'
-      CovType = ctrl % CovType
+     output_level = 'regular'
+     CovType = ctrl % CovType
 
      read(nl_fid, nml=settings, iostat=iostat, iomsg=iomsg)
      if (iostat /= 0) then
@@ -992,9 +992,12 @@ Contains
         call ModEM_abort()
      end if
 
-      write(0,*) "Optional namelist section '&settings' was read!"
-      ! NOTE: CovType namelist field is accepted but no longer processed.
-      ! CovType override sources (low->high priority): default(1) -> CLI 6th arg (-C) -> inv-ctrl 9th line (-I).
+     write(0,*) "Optional namelist section '&settings' was read!"
+     ! NOTE: CovType namelist field is accepted but no longer processed.
+     ! CovType override sources (low->high priority): default(1) -> CLI 6th arg (-C) -> inv-ctrl 9th line (-I).
+     if (CovType /= ctrl % CovType) then
+        write(0,*) 'WARNING: CovType from optional namelist is ignored (use -C CLI or inv-ctrl instead).'
+     end if
 
      ! Process output_level
      select case (output_level) ! Determine output_level number for comparision in CL arg
@@ -1054,7 +1057,7 @@ Contains
       write(nl_fid, *) "&settings"
       write(nl_fid, *) "    ! 'output_level' below overrides -V passed in on the command line"
       write(nl_fid, *) "    output_level = 'regular'"
-      write(nl_fid, *) "    ! CovType: 1 = AR (default), 2 = Bi-Helmholtz. (Note: namelist value is not currently applied; use -C CLI or inv-ctrl instead.)"
+       write(nl_fid, *) "    ! CovType: 1 = AR (default), 2 = H2 (Bi-Helmholtz). (Note: namelist value is not currently applied; use -C CLI or inv-ctrl instead.)"
       write(nl_fid, *) "    CovType = 1"
       write(nl_fid, *) "/"
 
@@ -1123,53 +1126,53 @@ Contains
 ! Returns found=.true. if a valid CovType override was read.
   subroutine read_covType_from_file(rFile, covType, found)
 
-   implicit none
-   character(*), intent(in)                    :: rFile
-   integer, intent(inout)                      :: covType
-   logical, intent(out)                        :: found
-   integer                                     :: iu, ios, i, parsedCovType, colonPos
-   logical                                     :: exists
-   character(256)                              :: line
+     implicit none
+     character(*), intent(in)                    :: rFile
+     integer, intent(inout)                      :: covType
+     logical, intent(out)                        :: found
+     integer                                     :: iu, ios, i, parsedCovType, colonPos
+     logical                                     :: exists
+     character(256)                              :: line
 
-   found = .false.
+     found = .false.
 
-   if (len_trim(rFile) <= 1) return
-   if (trim(rFile) == 'n') return
+     if (len_trim(rFile) <= 1) return
+     if (trim(rFile) == 'n') return
 
-   inquire(FILE=rFile, EXIST=exists)
-   if (.not. exists) return
+     inquire(FILE=rFile, EXIST=exists)
+     if (.not. exists) return
 
-   iu = 98
-   open(unit=iu, file=rFile, status='old', iostat=ios)
-   if (ios /= 0) return
+     iu = 98
+     open(unit=iu, file=rFile, status='old', iostat=ios)
+     if (ios /= 0) return
 
-   ! Skip required first 8 lines in inversion control format.
-   do i = 1, 8
-      read(iu, '(a)', iostat=ios) line
-      if (ios /= 0) then
-         close(iu)
-         return
-      end if
-   end do
+     ! Skip required first 8 lines in inversion control format.
+     do i = 1, 8
+        read(iu, '(a)', iostat=ios) line
+        if (ios /= 0) then
+           close(iu)
+           return
+        end if
+     end do
 
-   ! Optional 9th line: CovType selector, parsed from text after ':'
-   read(iu, '(a)', iostat=ios) line
-   if (ios == 0) then
-      colonPos = index(line, ':')
-      if (colonPos > 0) then
-         read(line(colonPos+1:), *, iostat=ios) parsedCovType
-         if (ios == 0) then
-            if ((parsedCovType == 1) .or. (parsedCovType == 2)) then
-               covType = parsedCovType
-               found = .true.
-            else
-               write(0,*) 'Warning: invalid CovType in inverse control file (expected 1 or 2): ', parsedCovType
-            end if
-         end if
-      end if
-   end if
+     ! Optional 9th line: CovType selector, parsed from text after ':'
+     read(iu, '(a)', iostat=ios) line
+     if (ios == 0) then
+        colonPos = index(line, ':')
+        if (colonPos > 0) then
+           read(line(colonPos+1:), *, iostat=ios) parsedCovType
+           if (ios == 0) then
+              if ((parsedCovType == 1) .or. (parsedCovType == 2)) then
+                 covType = parsedCovType
+                 found = .true.
+              else
+                 write(0,*) 'Warning: invalid CovType in inverse control file (expected 1 or 2): ', parsedCovType
+              end if
+           end if
+        end if
+     end if
 
-   close(iu)
+     close(iu)
 
   end subroutine read_covType_from_file
 
@@ -1186,22 +1189,22 @@ Contains
 ! set_CovType(ctrl%CovType).
   subroutine finalize_covType(ctrl)
 
-   implicit none
-   type(userdef_control), intent(inout) :: ctrl
+     implicit none
+     type(userdef_control), intent(inout) :: ctrl
 
-   integer                              :: covTypeRead
-   logical                              :: found
+     integer                              :: covTypeRead
+     logical                              :: found
 
-   ! Only INVERSE jobs have an inversion control file with a CovType line.
-   if (ctrl%job == INVERSE) then
-      call read_covType_from_file(ctrl%rFile_invCtrl, covTypeRead, found)
-      if (found) then
-         ctrl%CovType = covTypeRead
-         if (ctrl%output_level > 0) then
-            write(0,*) 'Setting CovType from inversion control file: ', covTypeRead
-         end if
-      end if
-   end if
+     ! Only INVERSE jobs have an inversion control file with a CovType line.
+     if (ctrl%job == INVERSE) then
+        call read_covType_from_file(ctrl%rFile_invCtrl, covTypeRead, found)
+        if (found) then
+           ctrl%CovType = covTypeRead
+           if (ctrl%output_level > 0) then
+              write(0,*) 'Setting CovType from inversion control file: ', covTypeRead
+           end if
+        end if
+     end if
 
   end subroutine finalize_covType
 

--- a/f90/UserCtrl.f90
+++ b/f90/UserCtrl.f90
@@ -134,7 +134,7 @@ Contains
   	ctrl%lambda = 10.
   	ctrl%eps = 1.0e-7
   	ctrl%delta = 0.05
-    ! 1 for AR, 2 for L1, 3 for L2
+    ! 1 for AR (default), 2 for Bi-Helmholtz
     ctrl%CovType = 1
   	ctrl%output_level = 3	
 	ctrl%prefix = 'n'
@@ -1054,7 +1054,7 @@ Contains
       write(nl_fid, *) "&settings"
       write(nl_fid, *) "    ! 'output_level' below overrides -V passed in on the command line"
       write(nl_fid, *) "    output_level = 'regular'"
-      write(nl_fid, *) "    ! CovType: 1 = AR (default), 2 = Bi-Helmholtz. Overrides -C CLI 6th arg, overridden by inv-ctrl 9th line."
+      write(nl_fid, *) "    ! CovType: 1 = AR (default), 2 = Bi-Helmholtz. (Note: namelist value is not currently applied; use -C CLI or inv-ctrl instead.)"
       write(nl_fid, *) "    CovType = 1"
       write(nl_fid, *) "/"
 
@@ -1180,11 +1180,10 @@ Contains
 !   Priority (low -> high):
 !     1) default (1) in initUserCtrl
 !     2) -C CLI optional 6th arg (APPLY_COV only)
-!     3) namelist.modem.nl &settings section
-!     4) inversion control file 9th line (-I only)
+!     3) inversion control file 9th line (-I only)
 !
-! Call this after parseArgs and process_optional_namelist, before
-! initGlobalData invokes set_CovType(ctrl%CovType).
+! Call this after parseArgs and before initGlobalData invokes
+! set_CovType(ctrl%CovType).
   subroutine finalize_covType(ctrl)
 
    implicit none


### PR DESCRIPTION
this adds a new Bi-Helmholtz covariance backend (CovType=2) alongside the default AR(1) implementation.

Unlike other inversion codes, ModEM is formulated in a transformed or perturbed model space:

```
 mHat = C_m^{1/2} (m - m0),
```

 so the "normal" model space can be expressed as:

```
 m = m0 + C_m^{-1/2} mHat
```

 where:
 - m is the physical model parameter field
 - m0 is the reference/prior model
 - C_m is (full) model covariance

This is useful, as the objective function can be expressed in the mHat space as:

Phi(mHat) = Phi_d(m0 + C_m^{-1/2} mHat) + lambda ||mHat||^2

where the gradient of the objective function is just:

```
grad_mHat Phi = C_m^{-1/2} J^T C_d^{-1} r + 2 * lambda mHat
```

which makes the model side of the gradient essentially identity. So some times we say that using the perturbed model space is like "using a preconditioner", which probably explains why ModEM inversion converges fast.

However, ModEM uses by default a first-order autoregressive (AR(1)) model covariance to regularize the 3D MT inversion since the EK12 formulation.

The model covariance is factorized as C_m = C^{1/2}C^{1/2}^T, where C^{1/2} is a sparse, matrix-free operator built from 1D recursive filters applied sequentially along x, y, z. This is cheap to implement, while avoids forming (or storing) the full covariance matrix.

While the AR(1) covariance is simple and efficient, it has been widely recognized as "weak" since the generated correlations are only along the grid axes and tend to generate prolonged structures along the axes, or the "measles" which are  . Applying the operator multiple  times (N>1) can help reduce those artifacts, but can be dangerous, as the inverse operator (C_m^{1/2}) can amplify high-frequency noise if applied for many times.

For the Bi-Helmholtz covariance we propose:

```
Cm^{-1/2} = kappa^2 I - Laplacian,
```

as a sparse CSR operator, with the forward or "roughning" operator C_m^{1/2} solved via Krylov subspace method (PCG with a Jacobi preconditioner). This produces isotropic (L2) correlation, which will (hopefully) address the overly rough structures associated with the AR(1) covariance. I used the name Bi-Helmholtz simply because the term looks like a Helmholtz equation when solving the operator... and the operator is applied twice for C_m

Please let me know if you have a better (more elegant) name.

The BiHelmholtz cov uses the same public methods as the AR(1) (create_CmSqrt, deall_CmSqrt, multBy_CmSqrt, multBy_Cm, multBy_CmSqrtInv). So in principle, the inversion methods (NLCG, LBFGS, etc.) need not to change to use CovType = 2 For now the default CovType is still 1, add another line in the inversion control file (9th line, -I only) to use CovType = 2, write something like:
```
Exit search when rms is less than  : 1.5
Exit when lambda is less than      : 1.0e-1
Maximum number of iterations       : 120
Covariance backend CovType         : 2
```
to use the new covariance type. Let me know if this works well for you!

files modified/added

-  modelCov/BiHelmholtz.hd adds a new modelCovBiHelm_t type: Nx, Ny, NzEarth, kappa, A (CSR), mask, pcg_tol, pcg_maxIt, tearMatrix, tearPairs, nrules. This is still under development
-  modelCov/BiHelmholtz.inc Basic interfaces - set_CovType / get_CovType; read_CmSqrt_BiHelm (file parser); create_CmSqrt_BiHelm / deall_CmSqrt_BiHelm; assemble_A_BiHelm (graph-Laplacian stencil with tear-pair exclusions); apply_A_BiHelm (CSR matvec); solve_A_BiHelm (PCG + Jacobi precond); multBy_CmSqrt_BiHelm / multBy_Cm_BiHelm / multBy_CmSqrtInv_BiHelm; apply_freeze_semantics_BiHelm (zeros air/ocean cells).
-  modelParam/ModelSpace.f90 added use spOpTools; included BiHelmholtz.hd/.inc; added CovType save variable (default 1); replaced monolithic covariance API with dispatcher functions (multBy_Cm, multBy_CmSqrt, multBy_CmSqrtInv, create_CmSqrt, deall_CmSqrt) (re)routing to _AR or _BiHelm backends.
-  modelCov/RecursiveAR.hd renamed public interfaces to _AR suffix: create_CmSqrt_AR, deall_CmSqrt_AR, multBy_CmSqrt_AR, read_CmSqrt_AR, multBy_Cm_AR.
-  modelCov/RecursiveAR.inc renamed all API subroutines/functions to _AR suffix;
-  UserCtrl.f90 added read_covType_from_file (parses inv-ctrl 9th line); added finalize_covType (highest-priority override); optional CovType in namelist &settings (accepted, not processed); -C handles optional 6th positional arg for CovType; updated help text for both -I and -C.
-  modelParam/modelParamIO.f90 guarded use Declaration_MPI and taskid check with #ifdef MPI (serial builds no longer reference MPI symbols in IO path).
-  Mod3DMT.f90 added finalize_covType(cUserDef) call for both MPI and serial paths before initGlobalData, so inversion control file override is active.
-  3D_MT/Main.f90 added set_CovType(cUserDef%CovType) call in initGlobalData.
-  3D_MT/Sub_MPI.f90, MPI/Main_MPI.f90 changed check_userdef_control_MPI intent(in) → intent(inout) changed Master_job_Distribute_userdef_control intent(in) → intent(inout) (required for CovType unpack).