### PR TITLE
Add data and model sections to optional namelist to change datatypes

### DIFF
--- a/f90/3D_MT/Sub_MPI.f90
+++ b/f90/3D_MT/Sub_MPI.f90
@@ -211,10 +211,10 @@ subroutine check_userdef_control_MPI (which_proc,ctrl)
     end if
 
     write(6,*)trim(which_proc),' : ctrl%prefix ',trim(ctrl%prefix)
-    write(6,*)trim(which_proc),' : ',trim(ctrl%data_input_ftype)
-    write(6,*)trim(which_proc),' : ',trim(ctrl%data_output_ftype)
-    write(6,*)trim(which_proc),' : ',trim(ctrl%model_input_ftype)
-    write(6,*)trim(which_proc),' : ',trim(ctrl%model_output_ftype)
+    write(6,*)trim(which_proc),' : ctrl%data_input_ftype ',trim(ctrl%data_input_ftype)
+    write(6,*)trim(which_proc),' : ctrl%data_output_ftype ',trim(ctrl%data_output_ftype)
+    write(6,*)trim(which_proc),' : ctrl%model_input_ftype ',trim(ctrl%model_input_ftype)
+    write(6,*)trim(which_proc),' : ctrl%model_output_ftype ',trim(ctrl%model_output_ftype)
     write(6,*)trim(which_proc),' : ctrl%storeSolnsInfile ',ctrl%storeSolnsInfile
 
     if (ctrl%SFF) then ! 'hidden option' only print if it has been set via namelist

--- a/f90/3D_MT/Sub_MPI.f90
+++ b/f90/3D_MT/Sub_MPI.f90
@@ -96,7 +96,7 @@ end subroutine count_number_of_messages_to_RECV
 	implicit none
 	integer Nbytes1,Nbytes2,Nbytes3,Nbytes4
 	!
-	CALL MPI_PACK_SIZE(80*26, MPI_CHARACTER,        MPI_COMM_WORLD, Nbytes1,  ierr)
+	CALL MPI_PACK_SIZE(80*31, MPI_CHARACTER,        MPI_COMM_WORLD, Nbytes1,  ierr)
 	CALL MPI_PACK_SIZE(3,     MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, Nbytes2,  ierr)
 	CALL MPI_PACK_SIZE(2,     MPI_INTEGER,          MPI_COMM_WORLD, Nbytes3,  ierr)
 	CALL MPI_PACK_SIZE(2,     MPI_LOGICAL,          MPI_COMM_WORLD, Nbytes4,  ierr)
@@ -116,7 +116,7 @@ end subroutine count_number_of_messages_to_RECV
      	type(userdef_control), intent(in)   :: ctrl
         integer index
         index=1
-        call MPI_Pack(ctrl%job,80*26, MPI_CHARACTER, userdef_control_package, Nbytes, index, MPI_COMM_WORLD, ierr)
+        call MPI_Pack(ctrl%job,80*31, MPI_CHARACTER, userdef_control_package, Nbytes, index, MPI_COMM_WORLD, ierr)
         call MPI_Pack(ctrl%lambda,3, MPI_DOUBLE_PRECISION, userdef_control_package, Nbytes, index, MPI_COMM_WORLD, ierr)
         call MPI_Pack(ctrl%CovType,1, MPI_INTEGER, userdef_control_package,  Nbytes, index, MPI_COMM_WORLD, ierr)
         call MPI_Pack(ctrl%output_level,1, MPI_INTEGER, userdef_control_package, Nbytes, index, MPI_COMM_WORLD, ierr)
@@ -165,6 +165,10 @@ end subroutine pack_userdef_control
    call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%search,80, MPI_CHARACTER,MPI_COMM_WORLD, ierr)
    call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%option,80, MPI_CHARACTER,MPI_COMM_WORLD, ierr)
    call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%prefix,80, MPI_CHARACTER,MPI_COMM_WORLD, ierr)
+   call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%data_input_ftype,80, MPI_CHARACTER,MPI_COMM_WORLD, ierr)
+   call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%data_output_ftype,80, MPI_CHARACTER,MPI_COMM_WORLD, ierr)
+   call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%model_input_ftype,80, MPI_CHARACTER,MPI_COMM_WORLD, ierr)
+   call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%model_output_ftype,80, MPI_CHARACTER,MPI_COMM_WORLD, ierr)
 
    call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%lambda,1, MPI_DOUBLE_PRECISION,MPI_COMM_WORLD, ierr)
    call MPI_Unpack(userdef_control_package, Nbytes, index, ctrl%eps,1, MPI_DOUBLE_PRECISION,MPI_COMM_WORLD, ierr)
@@ -207,6 +211,10 @@ subroutine check_userdef_control_MPI (which_proc,ctrl)
     end if
 
     write(6,*)trim(which_proc),' : ctrl%prefix ',trim(ctrl%prefix)
+    write(6,*)trim(which_proc),' : ',trim(ctrl%data_input_ftype)
+    write(6,*)trim(which_proc),' : ',trim(ctrl%data_output_ftype)
+    write(6,*)trim(which_proc),' : ',trim(ctrl%model_input_ftype)
+    write(6,*)trim(which_proc),' : ',trim(ctrl%model_output_ftype)
     write(6,*)trim(which_proc),' : ctrl%storeSolnsInfile ',ctrl%storeSolnsInfile
 
     if (ctrl%SFF) then ! 'hidden option' only print if it has been set via namelist

--- a/f90/3D_MT/modelParam/modelParamIO.f90
+++ b/f90/3D_MT/modelParam/modelParamIO.f90
@@ -46,10 +46,11 @@ submodule (ModelSpace) ModelSpaceIO
 
     ! Reading Intefaces
     interface
-        module subroutine read_modelParam_binary(grid, m, cfile)
+        module subroutine read_modelParam_binary(grid, airLayers, m, cfile)
             use GridDef, only : grid_t
             implicit none
             type(grid_t), target, intent(inout)  :: grid
+	        type(airLayers_t), intent(inout)     :: airLayers
             type(modelParam_t), intent(out)      :: m
             character(*), intent(in)  :: cfile
         end subroutine read_modelParam_binary
@@ -63,9 +64,10 @@ submodule (ModelSpace) ModelSpaceIO
             character(*), intent(in) :: cfile
         end subroutine read_modelParam_WS
 
-        module subroutine read_modelParam_mackie(grid, m, cfile)
+        module subroutine read_modelParam_mackie(grid, airLayers, m, cfile)
             implicit none
             type(grid_t), target, intent(inout) :: grid
+	        type(airLayers_t), intent(inout)	:: airLayers
             type(modelParam_t), intent(out) :: m
             character(*), intent(in) :: cfile
         end subroutine read_modelParam_mackie
@@ -187,9 +189,9 @@ contains
                 call read_modelParam_hdf5(grid, airLayers, m, cfile)
 #endif
             case (FTRAN_BINARY_FILE_TYPE)
-                call read_modelParam_binary(grid, m, cfile)
+                call read_modelParam_binary(grid, airLayers, m, cfile)
             case (MACKIE_FILE_TYPE)
-                call read_modelParam_mackie(grid, m, cfile)
+                call read_modelParam_mackie(grid, airLayers, m, cfile)
             case default
                 call unsupported_modelParamIO_error(INPUT_FILE_TYPE, INPUT)
         end select

--- a/f90/3D_MT/modelParam/modelParamIO/modelParam_IO_Binary.f90
+++ b/f90/3D_MT/modelParam/modelParamIO/modelParam_IO_Binary.f90
@@ -49,13 +49,14 @@ contains
       end subroutine write_modelParam_binary
 
   !******************************************************************
-   module subroutine read_modelParam_binary(grid,m,cfile)
+   module subroutine read_modelParam_binary(grid,airLayers, m,cfile)
 
    !  open cfile on unit ioPrm, writes out object of
    !   type modelParam in standard *binary* format (comparable
    !   format written by write_Cond3D), then close file
 
       type(grid_t), target, intent(inout)  :: grid
+	   type(airLayers_t), intent(inout)	   :: airLayers
       type(modelParam_t), intent(out)      :: m
       character(*), intent(in) 		       :: cfile
       integer                  :: ios
@@ -92,6 +93,13 @@ contains
 
 	  ! convert modelParam to the required paramType
 	  call setType_modelParam(m,paramType)
+
+      ! Now, finish set up of the air layers structure using the grid...
+      call setup_airlayers(airLayers,grid)
+
+      ! Finally, insert correct air layers in the grid and run setup_grid
+      call update_airlayers(grid,airLayers%Nz,airLayers%Dz)
+
 
 	  ! now done with ccond, so deallocate
 	  call deall_rscalar(ccond)

--- a/f90/3D_MT/modelParam/modelParamIO/modelParam_IO_Mackie.f90
+++ b/f90/3D_MT/modelParam/modelParamIO/modelParam_IO_Mackie.f90
@@ -10,7 +10,7 @@ contains
 ! I/O routines for 3D_MT modelParam - extended Randie Mackie's format
 
   !******************************************************************
-  module subroutine read_modelParam_mackie(grid,m,cfile)
+  module subroutine read_modelParam_mackie(grid,airLayers,m,cfile)
 
       !  open cfile on unit fid, writes out object of
       !   type modelParam in Randie Mackie's format, closes file
@@ -18,11 +18,12 @@ contains
       ! for setting the pointer to the grid in the modelParam
 
       type(grid_t), target, intent(inout) :: grid
+	  type(airLayers_t), intent(inout)	   :: airLayers
       type(modelParam_t), intent(out)	:: m
       character(*), intent(in)          :: cfile
       integer              :: ios
       ! local
-      character(80)                     :: type
+      character(80)                     :: type, paramType=''
       type(rscalar)                     :: ccond
 
  	  ! Read input files and set up basic grid geometry, conductivities,
@@ -35,7 +36,15 @@ contains
 	  call create_modelParam(grid,type,m,ccond)
 
 	  ! convert modelParam to the required paramType
-	  ! call setType_modelParam(m,paramType)
+      paramType = 'LOGE'
+	  call setType_modelParam(m,paramType)
+
+      ! Now, finish set up of the air layers structure using the grid...
+      call setup_airlayers(airLayers,grid)
+
+      ! Finally, insert correct air layers in the grid and run setup_grid
+      call update_airlayers(grid,airLayers%Nz,airLayers%Dz)
+
 
 	  ! now done with ccond, so deallocate
 	  call deall_rscalar(ccond)

--- a/f90/Mod3DMT.f90
+++ b/f90/Mod3DMT.f90
@@ -62,14 +62,10 @@ program Mod3DMT
       call process_optional_namelist(cUserDef)
       write(6,*)'I am a SERIAL version'
 #endif
+
+      call ModEM_setup_IO(cUserDef % data_input_ftype, cUserDef % data_output_ftype, &
+                    cUserDef % model_input_ftype, cUserDef % model_output_ftype)
  
-#ifdef HDF5
-      call ModEM_setup_IO(DATA_FILE_TYPE_HDF5, DATA_FILE_TYPE_HDF5, & ! Data Type
-                          HDF5_FILE_TYPE, HDF5_FILE_TYPE) ! Model Type
-#else
-      call ModEM_setup_IO(DATA_FILE_TYPE_ASCII, DATA_FILE_TYPE_ASCII, & ! Data Type
-                          WS_FILE_TYPE, WS_FILE_TYPE) ! Model Type
-#endif
       call initGlobalData(cUserDef)
       ! set the grid for the numerical computations
 #ifdef MPI

--- a/f90/UserCtrl.f90
+++ b/f90/UserCtrl.f90
@@ -146,12 +146,12 @@ Contains
 	ctrl%prefix = 'n'
 #ifdef HDF5
     ctrl%data_input_ftype = DATA_FILE_TYPE_HDF5
-    ctrl%data_output_Ftype = DATA_FILE_TYPE_HDF5
+    ctrl%data_output_ftype = DATA_FILE_TYPE_HDF5
     ctrl%model_input_ftype = HDF5_FILE_TYPE
     ctrl%model_output_ftype = HDF5_FILE_TYPE
 #else
     ctrl%data_input_ftype = DATA_FILE_TYPE_ASCII
-    ctrl%data_output_Ftype = DATA_FILE_TYPE_ASCII
+    ctrl%data_output_ftype = DATA_FILE_TYPE_ASCII
     ctrl%model_input_ftype = WS_FILE_TYPE
     ctrl%model_output_ftype = WS_FILE_TYPE
 #endif
@@ -906,8 +906,8 @@ Contains
 
      call gen_nml_section_settings(nl_fid)
      call gen_nml_section_grid(nl_fid)
-     call gen_nml_section_data_io(nl_fid)
-     call gen_nml_section_model_io(nl_fid)
+     call gen_nml_section_data(nl_fid)
+     call gen_nml_section_model(nl_fid)
 
      close(nl_fid)
 
@@ -950,10 +950,10 @@ Contains
      call process_nml_section_grid(ctrl, nl_fid)
      rewind(nl_fid) ! Technically not necessary, but just continuing the pattern
 
-     call process_nml_section_data_io(ctrl, nl_fid)
+     call process_nml_section_data(ctrl, nl_fid)
      rewind(nl_fid)
 
-     call process_nml_section_model_io(ctrl, nl_fid)
+     call process_nml_section_model(ctrl, nl_fid)
      rewind(nl_fid)
 
      close(nl_fid)
@@ -1112,7 +1112,7 @@ Contains
 
   end subroutine gen_nml_section_grid 
 
-  subroutine process_nml_section_data_io(ctrl, nl_fid)
+  subroutine process_nml_section_data(ctrl, nl_fid)
 
      implicit none
 
@@ -1125,39 +1125,39 @@ Contains
      integer :: iostat
      character (len=256) :: iomsg
 
-     namelist /data_io/ input_ftype, output_ftype
+     namelist /data/ input_ftype, output_ftype
 
      input_ftype = trim(ctrl % data_input_ftype)
      output_ftype = trim(ctrl % data_output_ftype)
 
-     read(nl_fid, nml=data_io, iostat=iostat, iomsg=iomsg)
+     read(nl_fid, nml=data, iostat=iostat, iomsg=iomsg)
      if (iostat /= 0) then
         ! Returns true if we have read to the EOF. Meaning that the section was not present (iostat == -1)
         if (IS_IOSTAT_END(iostat)) then 
-             write(0,*) "Optional namelist section '&data_io' was not present in ", trim(MODEM_NAMELIST), " skipping..."
+             write(0,*) "Optional namelist section '&data' was not present in ", trim(MODEM_NAMELIST), " skipping..."
              return
         end if
 
         ! Any other error means we have an error with the namelist
         ! that should be reported to the user
-        write(0,*) "ERROR: Processing namelist section '&data_io': ", trim(iomsg)
+        write(0,*) "ERROR: Processing namelist section '&data': ", trim(iomsg)
         call ModEM_abort()
      end if
 
-     write(0,*) "Optional namelist section '&data_io' was read!"
+     write(0,*) "Optional namelist section '&data' was read!"
 
      ctrl % data_input_ftype = trim(input_ftype)
      ctrl % data_output_ftype = trim(output_ftype)
 
-  end subroutine process_nml_section_data_io
+  end subroutine process_nml_section_data
 
-  subroutine gen_nml_section_data_io(nl_fid)
+  subroutine gen_nml_section_data(nl_fid)
 
      implicit none
 
      integer, intent(in) :: nl_fid
 
-     write(nl_fid, *) '&data_io'
+     write(nl_fid, *) '&data'
 #ifdef HDF5
      write(nl_fid, *) '    input_ftype = "HDF5"'
      write(nl_fid, *) '    output_ftype = "HDF5"'
@@ -1167,9 +1167,9 @@ Contains
 #endif
      write(nl_fid, *) '/'
 
-  end subroutine gen_nml_section_data_io
+  end subroutine gen_nml_section_data
 
-  subroutine process_nml_section_model_io(ctrl, nl_fid)
+  subroutine process_nml_section_model(ctrl, nl_fid)
 
      implicit none
 
@@ -1182,39 +1182,39 @@ Contains
      integer :: iostat
      character (len=256) :: iomsg
 
-     namelist /model_io/ input_ftype, output_ftype
+     namelist /model/ input_ftype, output_ftype
 
      input_ftype = trim(ctrl % model_input_ftype)
      output_ftype = trim(ctrl % model_output_ftype)
 
-     read(nl_fid, nml=model_io, iostat=iostat, iomsg=iomsg)
+     read(nl_fid, nml=model, iostat=iostat, iomsg=iomsg)
      if (iostat /= 0) then
         ! Returns true if we have read to the EOF. Meaning that the section was not present (iostat == -1)
         if (IS_IOSTAT_END(iostat)) then 
-             write(0,*) "Optional namelist section '&model_io' was not present in ", trim(MODEM_NAMELIST), " skipping..."
+             write(0,*) "Optional namelist section '&model' was not present in ", trim(MODEM_NAMELIST), " skipping..."
              return
         end if
 
         ! Any other error means we have an error with the namelist
         ! that should be reported to the user
-        write(0,*) "ERROR: Processing namelist section '&model_io': ", trim(iomsg)
+        write(0,*) "ERROR: Processing namelist section '&model': ", trim(iomsg)
         call ModEM_abort()
      end if
 
-     write(0,*) "Optional namelist section '&model_io' was read!"
+     write(0,*) "Optional namelist section '&model' was read!"
 
      ctrl % model_input_ftype = trim(input_ftype)
      ctrl % model_output_ftype = trim(output_ftype)
 
-  end subroutine process_nml_section_model_io
+  end subroutine process_nml_section_model
 
-  subroutine gen_nml_section_model_io(nl_fid)
+  subroutine gen_nml_section_model(nl_fid)
 
      implicit none
 
      integer, intent(in) :: nl_fid
 
-     write(nl_fid, *) '&model_io'
+     write(nl_fid, *) '&model'
 #ifdef HDF5
      write(nl_fid, *) '    input_ftype = "HDF5"'
      write(nl_fid, *) '    output_ftype = "HDF5"'
@@ -1224,6 +1224,6 @@ Contains
 #endif
      write(nl_fid, *) '/'
 
-  end subroutine gen_nml_section_model_io
+  end subroutine gen_nml_section_model
 
 end module UserCtrl

--- a/f90/UserCtrl.f90
+++ b/f90/UserCtrl.f90
@@ -70,6 +70,12 @@ module UserCtrl
     ! Out-of-core file prefix for storing working E-field solutions (NCI)
     character(80)       :: prefix
 
+    ! Data/Model input/output filetypes
+    character(80)       :: data_input_ftype
+    character(80)       :: data_output_ftype
+    character(80)       :: model_input_ftype
+    character(80)       :: model_output_ftype
+
 	! Specify damping parameter for the inversion
 	real(8)             :: lambda
 
@@ -138,6 +144,17 @@ Contains
     ctrl%CovType = 1
   	ctrl%output_level = 3	
 	ctrl%prefix = 'n'
+#ifdef HDF5
+    ctrl%data_input_ftype = DATA_FILE_TYPE_HDF5
+    ctrl%data_output_Ftype = DATA_FILE_TYPE_HDF5
+    ctrl%model_input_ftype = HDF5_FILE_TYPE
+    ctrl%model_output_ftype = HDF5_FILE_TYPE
+#else
+    ctrl%data_input_ftype = DATA_FILE_TYPE_ASCII
+    ctrl%data_output_Ftype = DATA_FILE_TYPE_ASCII
+    ctrl%model_input_ftype = WS_FILE_TYPE
+    ctrl%model_output_ftype = WS_FILE_TYPE
+#endif
 	ctrl%storeSolnsInFile = .false.
     ctrl%SFF = .false.
 
@@ -889,6 +906,8 @@ Contains
 
      call gen_nml_section_settings(nl_fid)
      call gen_nml_section_grid(nl_fid)
+     call gen_nml_section_data_io(nl_fid)
+     call gen_nml_section_model_io(nl_fid)
 
      close(nl_fid)
 
@@ -930,6 +949,12 @@ Contains
 
      call process_nml_section_grid(ctrl, nl_fid)
      rewind(nl_fid) ! Technically not necessary, but just continuing the pattern
+
+     call process_nml_section_data_io(ctrl, nl_fid)
+     rewind(nl_fid)
+
+     call process_nml_section_model_io(ctrl, nl_fid)
+     rewind(nl_fid)
 
      close(nl_fid)
 
@@ -1075,17 +1100,130 @@ Contains
 
   subroutine gen_nml_section_grid(nl_fid)
 
-      implicit none
+     implicit none
 
-      integer :: nl_fid
+     integer :: nl_fid
 
-      write(nl_fid, *) '&grid'
-      write(nl_fid, *) '    SFF = .false.  ! Currently unused'
-      write(nl_fid, *) '    primary_field = "file" ! Currently unused'
-      write(nl_fid, *) '    primary_field_file = "none" ! Currently unused'
-      write(nl_fid, *) '/'
+     write(nl_fid, *) '&grid'
+     write(nl_fid, *) '    SFF = .false.  ! Currently unused'
+     write(nl_fid, *) '    primary_field = "file" ! Currently unused'
+     write(nl_fid, *) '    primary_field_file = "none" ! Currently unused'
+     write(nl_fid, *) '/'
 
   end subroutine gen_nml_section_grid 
 
+  subroutine process_nml_section_data_io(ctrl, nl_fid)
+
+     implicit none
+
+     type (userdef_control), intent(inout) :: ctrl
+     integer, intent(in) :: nl_fid
+
+     character(len=80) :: input_ftype = ''
+     character(len=80) :: output_ftype = ''
+
+     integer :: iostat
+     character (len=256) :: iomsg
+
+     namelist /data_io/ input_ftype, output_ftype
+
+     input_ftype = trim(ctrl % data_input_ftype)
+     output_ftype = trim(ctrl % data_output_ftype)
+
+     read(nl_fid, nml=data_io, iostat=iostat, iomsg=iomsg)
+     if (iostat /= 0) then
+        ! Returns true if we have read to the EOF. Meaning that the section was not present (iostat == -1)
+        if (IS_IOSTAT_END(iostat)) then 
+             write(0,*) "Optional namelist section '&data_io' was not present in ", trim(MODEM_NAMELIST), " skipping..."
+             return
+        end if
+
+        ! Any other error means we have an error with the namelist
+        ! that should be reported to the user
+        write(0,*) "ERROR: Processing namelist section '&data_io': ", trim(iomsg)
+        call ModEM_abort()
+     end if
+
+     write(0,*) "Optional namelist section '&data_io' was read!"
+
+     ctrl % data_input_ftype = trim(input_ftype)
+     ctrl % data_output_ftype = trim(output_ftype)
+
+  end subroutine process_nml_section_data_io
+
+  subroutine gen_nml_section_data_io(nl_fid)
+
+     implicit none
+
+     integer, intent(in) :: nl_fid
+
+     write(nl_fid, *) '&data_io'
+#ifdef HDF5
+     write(nl_fid, *) '    input_ftype = "HDF5"'
+     write(nl_fid, *) '    output_ftype = "HDF5"'
+#else
+     write(nl_fid, *) '    input_ftype = "ASCII_LIST_FORMAT"'
+     write(nl_fid, *) '    output_ftype = "ASCII_LIST_FORMAT"'
+#endif
+     write(nl_fid, *) '/'
+
+  end subroutine gen_nml_section_data_io
+
+  subroutine process_nml_section_model_io(ctrl, nl_fid)
+
+     implicit none
+
+     type (userdef_control), intent(inout) :: ctrl
+     integer, intent(in) :: nl_fid
+
+     character(len=80) :: input_ftype = ''
+     character(len=80) :: output_ftype = ''
+
+     integer :: iostat
+     character (len=256) :: iomsg
+
+     namelist /model_io/ input_ftype, output_ftype
+
+     input_ftype = trim(ctrl % model_input_ftype)
+     output_ftype = trim(ctrl % model_output_ftype)
+
+     read(nl_fid, nml=model_io, iostat=iostat, iomsg=iomsg)
+     if (iostat /= 0) then
+        ! Returns true if we have read to the EOF. Meaning that the section was not present (iostat == -1)
+        if (IS_IOSTAT_END(iostat)) then 
+             write(0,*) "Optional namelist section '&model_io' was not present in ", trim(MODEM_NAMELIST), " skipping..."
+             return
+        end if
+
+        ! Any other error means we have an error with the namelist
+        ! that should be reported to the user
+        write(0,*) "ERROR: Processing namelist section '&model_io': ", trim(iomsg)
+        call ModEM_abort()
+     end if
+
+     write(0,*) "Optional namelist section '&model_io' was read!"
+
+     ctrl % model_input_ftype = trim(input_ftype)
+     ctrl % model_output_ftype = trim(output_ftype)
+
+  end subroutine process_nml_section_model_io
+
+  subroutine gen_nml_section_model_io(nl_fid)
+
+     implicit none
+
+     integer, intent(in) :: nl_fid
+
+     write(nl_fid, *) '&model_io'
+#ifdef HDF5
+     write(nl_fid, *) '    input_ftype = "HDF5"'
+     write(nl_fid, *) '    output_ftype = "HDF5"'
+#else
+     write(nl_fid, *) '    input_ftype = "WSINV3DMT"'
+     write(nl_fid, *) '    output_ftype = "WSINV3DMT"'
+#endif
+     write(nl_fid, *) '/'
+
+  end subroutine gen_nml_section_model_io
 
 end module UserCtrl


### PR DESCRIPTION
This merge builds off of #66 and #64  and updates the optional namelist to now take two new sections, data and model. These optional sections have input_ftype and output_ftype which will allow the user to select the input and output file type of the data and model file.

For HDF5 builds, the default choice for the namelist will be HDF5, for non-HDF5 builds it will be ASCII data list format and WSINV3DMT model types.

Again, you can generate the optional namelist by running the `-N` command of ModEM:

`./Mod3DMT_SP2 -N` 