### PR TITLE
Fix GPU stale lock state (when previous run was not shutdown properly)

### DIFF
--- a/f90/3D_MT/FWD_SP2/gpu_lock.h
+++ b/f90/3D_MT/FWD_SP2/gpu_lock.h
@@ -56,12 +56,21 @@ static inline int init_gpu_lock()
     // the winner does placement-new on every std::atomic<int>     
     // the other (losers) spin-wait with ACQUIRE on "cnstr" until it's 1, 
     // then proceed to use the atomics.
+    // firstly reset the atomics be to be a valid state (DEVICE_FREE) 
+    // before the other process access them
+    for (int i = 0; i < LOCK_MAX_DEVICES; i++)
+        g_lock->occupied[i].store(DEVICE_FREE, std::memory_order_release);
+
+    // useful for stale lock state if a previous run crashed or didn't 
+    // clean up properly. I only encountered this once in HIP, but not in 
+    // CUDA, so it may be a HIP bug.
 
     if (__atomic_exchange_n(&g_lock->cnstr, 1, __ATOMIC_ACQ_REL) != 0) {
         // Another process won the race — spin-wait until construction finishes.
         while (!__atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE))
             ;
-    } else {
+    } 
+    else {
         // We are the winner — construct all std::atomic members.
         for (int i = 0; i < LOCK_MAX_DEVICES; i++)
             new (&g_lock->occupied[i]) std::atomic<int>(DEVICE_FREE);
@@ -87,8 +96,11 @@ extern "C" void cf_releaseDev(int dev_idx)
 
 extern "C" void cf_cleanupLock()
 {
-    if (g_lock != nullptr && g_lock != MAP_FAILED)
+    if (g_lock != nullptr && g_lock != MAP_FAILED) {
+        // also reset cnstr so the next init_gpu_lock starts cleanly
+        __atomic_store_n(&g_lock->cnstr, 0, __ATOMIC_RELEASE);
         munmap(g_lock, sizeof(GpuLock));
+    }
     shm_unlink("/ModEM_gpu_lock");
     g_lock = nullptr;
     g_lock_inited = false;

--- a/f90/3D_MT/FWD_SP2/gpu_lock.h
+++ b/f90/3D_MT/FWD_SP2/gpu_lock.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <fcntl.h>
 #include <new>
+#include <sched.h>
 #include <sys/mman.h>
 #include <unistd.h>
 
@@ -51,36 +52,41 @@ static inline int init_gpu_lock()
     close(fd);
     if (g_lock == MAP_FAILED) { g_lock = nullptr; return 1; }
 
-    // Coordinate exactly-once construction of std::atomic members.   
-    // cnstr uses __atomic_* built-ins: safe on raw storage       
-    // cnstr: 0 = not constructed, 1 = atomics live, 2 = init in progress
-    // the winner does placement-new on every std::atomic<int>     
-    // the other (losers) spin-wait on 2, until it's 1, 
-    // then proceed to use the atomics.
-    // so CAS either succeeds, reveals cnstr=2 (spin), or reveals cnstr=1
-    // (ready).
-    // useful for stale lock state if a previous run crashed or didn't 
-    // clean up properly. I only encountered this once in HIP, but not in 
-    // CUDA, so it may be a HIP bug.
+    // Coordinate exactly-once construction of std::atomic members.
+    // cnstr uses __atomic_* built-ins: safe on raw storage before object
+    // lifetime begins.
+    // cnstr: 0 = not constructed, 2 = init in progress, 1 = atomics live.
+    //
+    // Retry loop:
+    //   - Only breaks when cnstr == 1 (atomics are live and ready).
+    //   - Retries initialization if cnstr goes 2 -> 0 (initializer crashed
+    //     or cleanup raced in).
+    //   - sched_yield() while waiting for another rank to finish so we
+    //     don't burn CPU on startup.
+    while (1) {
+        int old = __atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE);
+        if (old == 1) break;   // atomics are live, proceed
 
-    int old = __atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE);
+        if (old == 0) {
+            // Try to become the initializer: CAS 0 -> 2
+            if (__atomic_compare_exchange_n(&g_lock->cnstr, &old, 2,
+                                  false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+                for (int i = 0; i < LOCK_MAX_DEVICES; i++)
+                    new (&g_lock->occupied[i]) std::atomic<int>(DEVICE_FREE);
+                for (int i = 0; i < LOCK_MAX_DEVICES; i++)
+                    g_lock->occupied[i].store(DEVICE_FREE,
+                                              std::memory_order_release);
+                __atomic_store_n(&g_lock->cnstr, 1, __ATOMIC_RELEASE);
+                break;  // cnstr is now 1
+            }
+            // Another rank beat us to 0->2; fall through to yield and re-check
+        }
 
-    if (old == 2) {
-        while (__atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE) == 2)
-            ;
-    } else if (__atomic_compare_exchange_n(&g_lock->cnstr, &old, 2,
-                          false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
-    {
-        for (int i = 0; i < LOCK_MAX_DEVICES; i++)
-            new (&g_lock->occupied[i]) std::atomic<int>(DEVICE_FREE);
-        for (int i = 0; i < LOCK_MAX_DEVICES; i++)
-            g_lock->occupied[i].store(DEVICE_FREE, std::memory_order_release);
-        __atomic_store_n(&g_lock->cnstr, 1, __ATOMIC_RELEASE);
-    } else if (old == 2) {
-        while (__atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE) == 2)
-            ;
+        // cnstr == 2 (or we lost the CAS race): another init is in progress.
+        // Yield and retry; if the initializer crashed (cnstr reverts to 0) we
+        // will pick up init on the next iteration.
+        sched_yield();
     }
-    // else old == 1: someone completed init before our CAS, no action needed
 
     g_lock_inited = true;
     return 0;

--- a/f90/3D_MT/FWD_SP2/gpu_lock.h
+++ b/f90/3D_MT/FWD_SP2/gpu_lock.h
@@ -24,7 +24,7 @@ static constexpr int LOCK_MAX_DEVICES = 64;
 // All other members are std::atomic<int>, constructed by placement-new once,
 // then used via normal C++ atomic operations.
 struct alignas(64) GpuLock {
-    int cnstr;      // 0 = not constructed, 1 = atomics live
+    int cnstr;      // 0 = not constructed, 1 = atomics live, 2 = init in progress
     std::atomic<int> occupied[LOCK_MAX_DEVICES];
 };
 
@@ -53,31 +53,34 @@ static inline int init_gpu_lock()
 
     // Coordinate exactly-once construction of std::atomic members.   
     // cnstr uses __atomic_* built-ins: safe on raw storage       
+    // cnstr: 0 = not constructed, 1 = atomics live, 2 = init in progress
     // the winner does placement-new on every std::atomic<int>     
-    // the other (losers) spin-wait with ACQUIRE on "cnstr" until it's 1, 
+    // the other (losers) spin-wait on 2, until it's 1, 
     // then proceed to use the atomics.
-    // firstly reset the atomics be to be a valid state (DEVICE_FREE) 
-    // before the other process access them
-    for (int i = 0; i < LOCK_MAX_DEVICES; i++)
-        g_lock->occupied[i].store(DEVICE_FREE, std::memory_order_release);
-
+    // so CAS either succeeds, reveals cnstr=2 (spin), or reveals cnstr=1
+    // (ready).
     // useful for stale lock state if a previous run crashed or didn't 
     // clean up properly. I only encountered this once in HIP, but not in 
     // CUDA, so it may be a HIP bug.
 
-    if (__atomic_exchange_n(&g_lock->cnstr, 1, __ATOMIC_ACQ_REL) != 0) {
-        // Another process won the race — spin-wait until construction finishes.
-        while (!__atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE))
+    int old = __atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE);
+
+    if (old == 2) {
+        while (__atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE) == 2)
             ;
-    } 
-    else {
-        // We are the winner — construct all std::atomic members.
+    } else if (__atomic_compare_exchange_n(&g_lock->cnstr, &old, 2,
+                          false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+    {
         for (int i = 0; i < LOCK_MAX_DEVICES; i++)
             new (&g_lock->occupied[i]) std::atomic<int>(DEVICE_FREE);
-
-        // cnstr is already 1 from the exchange above (ACQ_REL ensures
-        // the constructed atomics are visible to other processes).
+        for (int i = 0; i < LOCK_MAX_DEVICES; i++)
+            g_lock->occupied[i].store(DEVICE_FREE, std::memory_order_release);
+        __atomic_store_n(&g_lock->cnstr, 1, __ATOMIC_RELEASE);
+    } else if (old == 2) {
+        while (__atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE) == 2)
+            ;
     }
+    // else old == 1: someone completed init before our CAS, no action needed
 
     g_lock_inited = true;
     return 0;

--- a/f90/3D_MT/FWD_SP2/gpu_lock.h
+++ b/f90/3D_MT/FWD_SP2/gpu_lock.h
@@ -52,40 +52,43 @@ static inline int init_gpu_lock()
     close(fd);
     if (g_lock == MAP_FAILED) { g_lock = nullptr; return 1; }
 
-    // Coordinate exactly-once construction of std::atomic members.
-    // cnstr uses __atomic_* built-ins: safe on raw storage before object
-    // lifetime begins.
-    // cnstr: 0 = not constructed, 2 = init in progress, 1 = atomics live.
+    // Exactly-once (re-)initialization of std::atomic members.
+    // cnstr: 0=uninit/stale, 2=init-in-progress, 1=ready.
     //
-    // Retry loop:
-    //   - Only breaks when cnstr == 1 (atomics are live and ready).
-    //   - Retries initialization if cnstr goes 2 -> 0 (initializer crashed
-    //     or cleanup raced in).
-    //   - sched_yield() while waiting for another rank to finish so we
-    //     don't burn CPU on startup.
-    while (1) {
-        int old = __atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE);
-        if (old == 1) break;   // atomics are live, proceed
+    // Both 0 (fresh shm) and 1 (stale from a previous crash — some
+    // occupied[] may still be DEVICE_IN_USE) trigger CAS to 2. The
+    // winner does placement-new + reset, clearing all stale lock bits.
+    // Losers yield while cnstr == 2. If the initializer crashes, cnstr
+    // may revert to 0; the next iteration retries.
+    //
+    // A cleanly-terminated previous job always calls shm_unlink, so
+    // finding an existing segment implies the last job crashed — it is
+    // safe to reconstruct atomics unconditionally.
 
-        if (old == 0) {
-            // Try to become the initializer: CAS 0 -> 2
-            if (__atomic_compare_exchange_n(&g_lock->cnstr, &old, 2,
-                                  false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
-                for (int i = 0; i < LOCK_MAX_DEVICES; i++)
-                    new (&g_lock->occupied[i]) std::atomic<int>(DEVICE_FREE);
-                for (int i = 0; i < LOCK_MAX_DEVICES; i++)
-                    g_lock->occupied[i].store(DEVICE_FREE,
-                                              std::memory_order_release);
-                __atomic_store_n(&g_lock->cnstr, 1, __ATOMIC_RELEASE);
-                break;  // cnstr is now 1
-            }
-            // Another rank beat us to 0->2; fall through to yield and re-check
+    for (;;) {
+        int old = __atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE);
+
+        if (old == 2) {
+            do {
+                sched_yield();
+                old = __atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE);
+            } while (old == 2);
+            continue;
         }
 
-        // cnstr == 2 (or we lost the CAS race): another init is in progress.
-        // Yield and retry; if the initializer crashed (cnstr reverts to 0) we
-        // will pick up init on the next iteration.
-        sched_yield();
+        // old is 0 (fresh) or 1 (stale ready with possibly stuck locks).
+        // Try CAS {0, 1} → 2 to become the (re-)initializer.
+        if (__atomic_compare_exchange_n(&g_lock->cnstr, &old, 2,
+                                         false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+        {
+            for (int i = 0; i < LOCK_MAX_DEVICES; i++)
+                new (&g_lock->occupied[i]) std::atomic<int>(DEVICE_FREE);
+            for (int i = 0; i < LOCK_MAX_DEVICES; i++)
+                g_lock->occupied[i].store(DEVICE_FREE, std::memory_order_release);
+            __atomic_store_n(&g_lock->cnstr, 1, __ATOMIC_RELEASE);
+            break;
+        }
+        // CAS failed — another rank changed cnstr; loop re-evaluates.
     }
 
     g_lock_inited = true;

--- a/f90/3D_MT/FWD_SP2/gpu_lock.h
+++ b/f90/3D_MT/FWD_SP2/gpu_lock.h
@@ -65,11 +65,13 @@ static inline int init_gpu_lock()
     // finding an existing segment implies the last job crashed — it is
     // safe to reconstruct atomics unconditionally.
 
-    for (;;) {
+    while (1) {
         int old = __atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE);
 
         if (old == 2) {
+	        // Another rank is initializing; yield until it finishes.
             do {
+		        // yield, instead of busy-waiting...
                 sched_yield();
                 old = __atomic_load_n(&g_lock->cnstr, __ATOMIC_ACQUIRE);
             } while (old == 2);
@@ -88,7 +90,8 @@ static inline int init_gpu_lock()
             __atomic_store_n(&g_lock->cnstr, 1, __ATOMIC_RELEASE);
             break;
         }
-        // CAS failed — another rank changed cnstr; loop re-evaluates.
+        // else
+        // CAS failed — another rank changed cnstr; loop and re-evaluates.
     }
 
     g_lock_inited = true;


### PR DESCRIPTION
resets the atomics to be a valid state (DEVICE_FREE)  before the other processes access them.

This is useful to reset the stale lock state when a previous run crashed or didn't clean up properly. I only encountered this kind of things once in HIP, but not in CUDA, so it may be a HIP bug, after all...