### PR TITLE
Fix MT polarization mode name mislabeling in solution/RHS I/O

### DIFF
--- a/f90/3D_MT/SolnSpace.f90
+++ b/f90/3D_MT/SolnSpace.f90
@@ -197,10 +197,19 @@ contains
        
        ! set up the mode names based on transmitter type;
        ! for now, only set up for MT. Used for I/O.
+       ! FIX (2026-07-27): boundary_ws.f90/boundary_wsS.f90's BC_x0_WS computes
+       ! imode=1 as Ey-polarization (only E0%y set) and imode=2 as
+       ! Ex-polarization (only E0%x set) -- the labels below previously had
+       ! this backwards (Pol_name(1)='Ex'), mislabeling the ModeName string
+       ! written into .esoln/.rhs file headers. Confirmed cosmetic-only: Pol_name
+       ! is never read by DataFunc.f90 or any other data/impedance/Jacobian
+       ! code (those use the plain integer index throughout), so this does not
+       ! change Zxy/Zyx, transfer functions, -F predicted-data output, or
+       ! inversion results -- only the descriptive label in solution/RHS files.
        if (trim(txDict(iTx)%tx_type) .eq. 'MT') then
         if (e%nPol == 2) then
-            e%Pol_name(1) = 'Ex'
-            e%Pol_name(2) = 'Ey'
+            e%Pol_name(1) = 'Ey'
+            e%Pol_name(2) = 'Ex'
         else
          call errStop('problem creating MT modes in create_solnVector')
         end if
@@ -797,10 +806,13 @@ contains
 
        ! set up the mode names based on transmitter type;
        ! for now, only set up for MT. Used for I/O.
+       ! FIX (2026-07-27): see the matching note in create_solnVector above --
+       ! imode=1 is actually Ey-polarization, imode=2 is Ex-polarization, per
+       ! boundary_ws.f90/boundary_wsS.f90's BC_x0_WS. Cosmetic-only label fix.
        if (trim(txDict(iTx)%tx_type) .eq. 'MT') then
         if (b%nPol == 2) then
-            b%Pol_name(1) = 'Ex'
-            b%Pol_name(2) = 'Ey'
+            b%Pol_name(1) = 'Ey'
+            b%Pol_name(2) = 'Ex'
         else
          call errStop('problem creating MT modes in create_rhsVector')
         end if


### PR DESCRIPTION
Throughout ModEM — boundary_ws.f90 and boundary_wsS.f90 (identical convention in both), and the write loop do k=1,2 that calls EfileWrite(..., k, ...) — array position/index 1 is Ey-polarization-dominant, and index 2 is Ex-polarization-dominant. Accordingly, the real, physical write order in the binary electric field output file (unaffected by the label bug) is: for each period, block 1 = Ey-polarization solution, block 2 = Ex-polarization solution. Note also that the Matlab reader (rdExyzAll.m) also has it right: it hardcodes Modes={'Y','X'}, i.e. Modes{1}='Y' (Ey), Modes{2}='X' (Ex).

However, the string written into each block's header ('Ey'/'Ex' from Pol_name) had them backwards — note however that the block order and the field data themselves are correct and self-consistent throughout the rest of the codebase (confirmed that DataFunc.f90 never reads Pol_name, only the integer index). In SolnSpace.f90, only the character labels in create_solnVector and create_rhsVector were reversed but are now correctly hardcoded Pol_name(1)='Ey', Pol_name(2)='Ex'.

This only corrects the descriptive ModeName string written into .esoln/.rhs file headers. Zxy/Zyx, transfer functions, -F predicted-data output, and inversion results are unaffected; no existing results need to be rerun. This particular finding is confirmed thoroughly using Claude by direct inspection of solved field magnitudes (position 1 is Ey-dominant, position 2 is Ex-dominant, both Cartesian and spherical builds) and by tracing that Pol_name is never read by DataFunc.f90 or any other data/Jacobian code, which use the plain integer index throughout.