### PR TITLE
Add a section in the docs about the new Namelist

### DIFF
--- a/docs/source/building_with_cmake.rst
+++ b/docs/source/building_with_cmake.rst
@@ -239,6 +239,8 @@ also explicitly specify your feature set:
     $ cmake .. -DCMAKE_Fortran_FLAGS="-msse4.2"
 
 
+.. _building_modem_spherical:
+
 
 Building ModEM Spherical Version
 ==================================

--- a/docs/source/file_formats.rst
+++ b/docs/source/file_formats.rst
@@ -264,19 +264,34 @@ to in the ModEM code, perhaps inappropriately, as the “Mackie format”.) Thes
 two formats are similar, but not identical. At present switching between these
 model formats requires editing and recompiling the program.
 
-(For completeness here is a very brief summary of the modifications required:
-read routines are in ``f90/3D_MT/modelParam/modelParamIO/*.inc``.  All of these
-files are included in the compiled ModelSpace module (with compiler directives
-``#include``). The names of the read and write routines are
-``read_modelParam_WS(mackie)`` and similarly for write. The read/write routines
-in use are overloaded on ``read_modelParam`` (and similarly for the write
-routine; this is done in ``f90/3D_MT/modelParam/ModelSpace.f90``), and calls to
-these generic read/write subroutines are then used in the program to input or
-output model parameter objects. Both the "WS" and "Mackie" read/write routines
-(and others that one might want to implement) must have identical interfaces.
-Then, by changing the names of routine overloaded in the ``ModelSpace``
-interface, the expected file format used for model parameter I/O is changed.
-Yes, better approaches could be imagined!)
+ModEM can now switch between model file formats easily by using the optional
+ModEM Namelist. To do so, genearte the ModEM namelist by running a ModEM
+executable with -N:
+
+.. code-block:: bash
+
+   $ ./Mod3DMT -N
+
+Then, in the IO section of ModEM, change the ``model_input_format`` (or
+``model_output_format``) to your desired format:
+
+
+.. code-block:: text
+
+    &io
+         data_input_format = 'ASCII'
+         data_output_format = 'ASCII'
+         model_input_format = 'RM'
+         model_output_format = 'WS'
+         efield_input_format = 'binary'
+         efield_output_format = 'binary'
+     /
+
+The above namelist IO section will then set ModEM to read in a Randall Mackie
+('RM') format.
+
+Please see :ref:`modem-namelist` and :ref:`converting-file-formats` for more
+information.
 
 Both of the currently supported model file formats begin with a description of
 the tensor-product Cartesian grid: cell dimensions in ``x``, ``y``, and ``z``
@@ -859,3 +874,53 @@ topography and having problems, double check that you are defining vertical
 levels consistently in the model and data files.  Again, using tools for model
 and data file setup (such as Grid3D) can help ensure consistency–if these are
 used correctly!
+
+
+
+.. _converting-file-formats:
+
+Converting Between Data and Model File Formats
+------------------------------------------------
+
+It can be useful to convert between different file formats. This can be easily
+done with ModEM by using the optional ModEM namelist and using the
+``-R``/Read-write command line argument.
+
+For instance, we can use this method to convert between Weerachai
+Siripunvaraporn’s WSINV3DMT (WS) and Randall Mackie's format (RM):
+
+First, generate the ModEM namelist by running ModEM with -N:
+
+.. code-block:: bash
+
+    $ ./Mod3DMT_SP2 -N
+
+This will generate a ModEM namelist file named ``modem.namelist.nl``. We can
+edit the ``model_input_format`` and ``model_output_format`` in the ``io``
+section of the namelist to specify that we want ModEM to read in a WS model
+file and writeout a RM file:
+
+.. code-block:: text
+
+    &io
+         data_input_format = 'ASCII'
+         data_output_format = 'ASCII'
+         model_input_format = 'WS'
+         model_output_format = 'RW'
+         efield_input_format = 'binary'
+         efield_output_format = 'binary'
+     /
+
+
+Then, we can run ModEM with -R to convert our model file from WS to RM:
+
+.. code-block:: bash
+
+    $ ./Mod3DMT_SP2 -R model.ws de.dat model.rm de.out
+
+The output file ``model.rm`` will then be in the Randal Mackie (RM) format.
+
+Of course, this can also be used to convert data files in a similar manner.
+Furthermore, these options apply to any ModEM option. So, if desired, one could
+read in a WS file for an inversion, and then write all inversion model output
+as RM.

--- a/docs/source/file_formats.rst
+++ b/docs/source/file_formats.rst
@@ -571,6 +571,8 @@ Blocks are repeated as necessary — a single block is used in the simple exampl
 indicating that the regions extend over all 11 layers (top-to-bottom) of this
 very small grid.
 
+.. _h2-covariance-type:
+
 H2 (Bi-Helmholtz) Covariance (CovType=2)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,6 +38,7 @@ options for inversion, etc.
 
    obtaining_modem
    getting_started
+   modem_namelist
    building_with_cmake
    file_formats
    forward_and_inversion

--- a/docs/source/modem_namelist.rst
+++ b/docs/source/modem_namelist.rst
@@ -29,7 +29,8 @@ Each namelist section is optional and can be omitted completely if desired.
     &settings
         ! 'output_level' below overrides -V passed in on the command line
         output_level = 'regular'
-        ! CovType: 'AR' (default),  'H2' (Bi-Helmholtz) 
+        ! Covariance Type: 'AR' (default),  'H2' (Bi-Helmholtz) 
+        ! Currently performs no actions - use Inv control file or command line arg
         covariance_type = 'AR'
     /
     &io
@@ -42,11 +43,11 @@ Each namelist section is optional and can be omitted completely if desired.
      /
      &forward
          SFF = .false.
-         primary_model = "file"
-         primary_model_file = "none"
-         primary_field = "file"
-         primary_field_file = "none"
-         esoln_output = "none"
+         primary_model = 'file'
+         primary_model_file = 'none'
+         primary_field = 'file'
+         primary_field_file = 'none'
+         esoln_output = 'none'
      /
      &spherical_mt
          ! This section is only generated and processed if
@@ -54,6 +55,8 @@ Each namelist section is optional and can be omitted completely if desired.
          fake_grid = .false.
          fake_center_latlon = 0.0d0, 90.0d0
          fake_data_orientation = .true.
+         external_source_file = 'none'
+
      /
 
 
@@ -80,8 +83,17 @@ settings Section
     |                 |                             |           | the command line.                           |
     +-----------------+-----------------------------+-----------+---------------------------------------------+
     | covariance_type | 'AR', 'H2'                  | 'AR'      | Covariance type for inversion.              |
-    |                 |                             |           |                                             |
+    |                 |                             |           | Currently has no effect, see note below.    |
     +-----------------+-----------------------------+-----------+---------------------------------------------+
+
+
+.. note::
+
+   The `covariance_type` Namelist option currently has no effect. To set it,
+   use the 'Covariance backend CovType' option in the inversion control file.
+   Additional reference on the covariance type can be found at:
+   :ref:`h2-covariance-type`.
+
 
 forward Section
 ~~~~~~~~~~~~~~~~

--- a/docs/source/modem_namelist.rst
+++ b/docs/source/modem_namelist.rst
@@ -1,0 +1,180 @@
+.. _modem-namelist:
+
+ModEM Namelist - Additional Settings
+=====================================
+
+ModEM now has a Fortran Namelist which can be used to supply ModEM with runtime
+options. So far, this name list is completely optional; however, it may provide
+some features which are convenient and useful.
+
+A Fortran namelist is a file that can provide input for Fortran executables.
+The ModEM namelist must be named ``modem.namelist.nl`` and must be present in
+the same directory as you run the ModEM executable.
+
+A copy of the ModEM namelist is listed below, but you can also use a ModEM
+executable by using the ``-N`` command line argument:
+
+.. code-block:: bash
+
+    $ ./Mod3DMT_SP2 -N
+
+This will create a file named ``modem.namelist.nl`` in the current directory.
+If this file already exists, ModEM will *not* create this file.
+
+Each namelist section is optional and can be omitted completely if desired.
+
+.. code-block:: text
+   :caption: Example ModEM Namelist file
+
+    &settings
+        ! 'output_level' below overrides -V passed in on the command line
+        output_level = 'regular'
+        ! CovType: 'AR' (default),  'H2' (Bi-Helmholtz) 
+        covariance_type = 'AR'
+    /
+    &io
+         data_input_format = 'ASCII'
+         data_output_format = 'ASCII'
+         model_input_format = 'WS'
+         model_output_format = 'WS'
+         efield_input_format = 'binary'
+         efield_output_format = 'binary'
+     /
+     &forward
+         SFF = .false.
+         primary_model = "file"
+         primary_model_file = "none"
+         primary_field = "file"
+         primary_field_file = "none"
+         esoln_output = "none"
+     /
+     &spherical_mt
+         ! This section is only generated and processed if
+         ! ModEM is built with spherical coordinates
+         fake_grid = .false.
+         fake_center_latlon = 0.0d0, 90.0d0
+         fake_data_orientation = .true.
+     /
+
+
+.. |br| raw:: html
+
+   <br />
+
+
+Namelist Options Reference
+-----------------------------
+
+settings Section
+~~~~~~~~~~~~~~~~~
+
+.. table :: &settings namelist options 
+    :widths: 15 15 7 30
+
+    +-----------------+-----------------------------+-----------+---------------------------------------------+
+    | Name            | Values                      | Default   | Description                                 |
+    +=================+=============================+===========+=============================================+
+    | output_level    | 'debug', 'full', 'regular', | 'regular' | Indicates the desire level of output level  |
+    |                 | 'compact', 'result', 'none' |           | to the screen and to files.                 |
+    |                 |                             |           | Note: This value will override -v passed on |
+    |                 |                             |           | the command line.                           |
+    +-----------------+-----------------------------+-----------+---------------------------------------------+
+    | covariance_type | 'AR', 'H2'                  | 'AR'      | Covariance type for inversion.              |
+    |                 |                             |           |                                             |
+    +-----------------+-----------------------------+-----------+---------------------------------------------+
+
+forward Section
+~~~~~~~~~~~~~~~~
+
+
+.. table :: &forward namelist options 
+    :widths: 15 15 7 30
+
+    +--------------------+-------------------+-----------+---------------------------------------------------------------+
+    | Name               | Values            | Default   | Description                                                   |
+    +====================+===================+===========+===============================================================+
+    | SFF                | .true., .false.   | .false.   | .true. forces the secondary field formulation                 |
+    +--------------------+-------------------+-----------+---------------------------------------------------------------+
+    | primary_model      | 'file', 'average' | 'file'    | Source of the 1D model.                                       |
+    |                    |                   |           | 'file': Read from the specified at primary_model_file.        |
+    |                    |                   |           | 'average': 'Avg Description'.                                 |
+    |                    |                   |           | Only applicable if 'SFF' is .true.                            |
+    +--------------------+-------------------+-----------+---------------------------------------------------------------+
+    | primary_model_file | Path to primary   | 'none'    | Path to primary model file to use for SFF.                    |
+    |                    | model file        |           | Only applicable if 'SFF' is .true. AND 'primary_model'        |
+    |                    |                   |           | is set to 'file'                                              |
+    +--------------------+-------------------+-----------+---------------------------------------------------------------+
+    | primary_field      | 'file', 'compute' | 'file'    | Source of the primary E-Field: 'file': read from file         |
+    |                    |                   |           | specified in primary_field_file. 'compute': compute           |
+    |                    |                   |           | the primary field internally.                                 |
+    |                    |                   |           | Only applicable if 'SFF' is .ture.                            |
+    +--------------------+-------------------+-----------+---------------------------------------------------------------+
+    | primary_field_file | Path to primary   | 'none'    | Path to primary E-Field file to use for SFF. Only             |
+    |                    | field file        |           | applicable if SFF is true and primary_field_file              |
+    |                    |                   |           | is set to 'file'                                              |
+    +--------------------+-------------------+-----------+---------------------------------------------------------------+
+    | esoln_output       | 'ALL',            | 'ALL'     | EM solution output granularity.                               |
+    |                    | 'PER_PERIOD',     |           | 'All': Write all esolns output into one file.                 |
+    |                    | 'PER_PERIOD_MODE' |           | 'PER_PERIOD': Write esolns output into a file for each period |
+    |                    |                   |           | 'PER_PERIOD_MODE': Write esolns into a file for each period   |
+    |                    |                   |           | and mode.                                                     |
+    +--------------------+-------------------+-----------+---------------------------------------------------------------+
+
+io Section
+~~~~~~~~~~~
+
+.. table :: &io namelist options 
+    :widths: 15 15 7 30
+
+    +------------------------+-----------------------------+-----------+----------------------------------------------------+
+    | Name                   | Values                      | Default   | Description                                        |
+    +========================+=============================+===========+====================================================+
+    | data_input_format      | 'ASCII', 'HDF5'             | 'ASCII'   | Input format for data                              |
+    +------------------------+-----------------------------+-----------+----------------------------------------------------+
+    | data_output_format     | Same as data_input_format   | 'ASCII'   | Output format for data                             |
+    +------------------------+-----------------------------+-----------+----------------------------------------------------+
+    | model_input_format     | 'WS', 'HDF5', 'binary',     | 'WS'      | Input format for the model.                        |
+    |                        |                             |           | 'WS': ModEM version of Weerachai Siripunvaraporn’s.|
+    |                        |                             |           | WSINV3DMT model version.                           |
+    |                        |                             |           | 'HDF5': Only available if ModEM                    |
+    |                        |                             |           | is built with HDF5.                                |
+    |                        |                             |           | 'binary': Fortran Binary Format.                   |
+    |                        |                             |           | 'RM': Based on Randall Mackie                      |
+    |                        |                             |           | model format.                                      |
+    +------------------------+-----------------------------+-----------+----------------------------------------------------+
+    | model_output_format    | Same as model_input_format  | 'WS'      | Output format for the model.                       |
+    |                        |                             |           | Same options as model_input_format                 |
+    +------------------------+-----------------------------+-----------+----------------------------------------------------+
+    | efield_input_format    | 'binary', 'HDF5', 'ASCII'   | 'binary'  | Input file format for electric field               |
+    +------------------------+-----------------------------+-----------+----------------------------------------------------+
+    | efield_output_format   | Same as efield_input_format | 'binary'  | Output file format for electric field              |
+    +------------------------+-----------------------------+-----------+----------------------------------------------------+
+    | jacobian_output_format | 'binary', 'ASCII'           | 'binary'  | Output file format for the Jacobian                |
+    +------------------------+-----------------------------+-----------+----------------------------------------------------+
+
+sphereical_mt Section
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+   The ``&spherical_mt`` is only generated and processed if ModEM is built with
+   spherical coordinates. See :ref:`building_modem_spherical` for more
+   information on building ModEM in spherical coordinates.
+
+
+.. table :: &spherical_mt namelist options 
+    :widths: 15 15 7 30
+
+    +------------------------+-----------------------------+---------------+---------------------------------------------+
+    | Name                   | Values                      | Default       | Description                                 |
+    +========================+=============================+===============+=============================================+
+    | fake_grid              | .true., .false.             | .false.       | .false.: Do not apply grid rotation to      |
+    |                        |                             |               | equator                                     |
+    +------------------------+-----------------------------+---------------+---------------------------------------------+
+    | fake_center_latlon     | lat, lon                    | 0.0d0, 90.0d0 | Fake grid center if fake_grid is .true.     |
+    +------------------------+-----------------------------+---------------+---------------------------------------------+
+    | fake_data_orientation  | .true., .false.             | .true.        | Orient the data to geographic using         |
+    |                        |                             |               | fake_center_latlon                          |
+    +------------------------+-----------------------------+---------------+---------------------------------------------+
+
+


### PR DESCRIPTION
This commit adds a new page to the docs modem_namelist.rst. It contains information about the namelist options and how it can be generated using a ModEM executable.

The tables are a bit wonky to work with and there might be a better solution. It is quite a pain to get the formatting of the table correctly, and RST is pretty picky about things lining up correctly. However, for now, this should be sufficient.

This commit also updates file_formats.rst and removes the old method for altering ModEM to read in RM files as we can now use the namelist combined with -R. It also adds a small section on how users can convert Model and data file formats.

Soon we will update this section with information on converting to HDF5.